### PR TITLE
Cross-platform release workflow with Linux aarch64 and checksums

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,11 +12,15 @@ jobs:
     name: Build (${{ matrix.target }})
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
             artifact: noupling-linux-x86_64
+          - os: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            artifact: noupling-linux-aarch64
           - os: macos-latest
             target: aarch64-apple-darwin
             artifact: noupling-macos-aarch64
@@ -28,11 +32,24 @@ jobs:
             artifact: noupling-windows-x86_64.exe
     steps:
       - uses: actions/checkout@v4
+
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools (Linux aarch64)
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> $GITHUB_ENV
+
       - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
       - run: cargo build --release --target ${{ matrix.target }}
+
       - name: Rename binary
         shell: bash
         run: |
@@ -40,11 +57,19 @@ jobs:
             cp target/${{ matrix.target }}/release/noupling.exe ${{ matrix.artifact }}
           else
             cp target/${{ matrix.target }}/release/noupling ${{ matrix.artifact }}
+            chmod +x ${{ matrix.artifact }}
           fi
+
+      - name: Generate SHA256 checksum
+        shell: bash
+        run: shasum -a 256 ${{ matrix.artifact }} > ${{ matrix.artifact }}.sha256
+
       - uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact }}
-          path: ${{ matrix.artifact }}
+          path: |
+            ${{ matrix.artifact }}
+            ${{ matrix.artifact }}.sha256
 
   release:
     name: Create Release
@@ -52,14 +77,25 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           merge-multiple: true
+
+      - name: Display checksums
+        run: cat *.sha256
+
       - uses: softprops/action-gh-release@v2
         with:
           files: |
             noupling-linux-x86_64
+            noupling-linux-x86_64.sha256
+            noupling-linux-aarch64
+            noupling-linux-aarch64.sha256
             noupling-macos-aarch64
+            noupling-macos-aarch64.sha256
             noupling-macos-x86_64
+            noupling-macos-x86_64.sha256
             noupling-windows-x86_64.exe
+            noupling-windows-x86_64.exe.sha256
           generate_release_notes: true


### PR DESCRIPTION
## Summary

- Adds Linux aarch64 target (5 platforms total)
- Generates SHA256 checksum files for all binaries
- Sets executable permissions on Unix binaries
- Per-target cache keys and fail-fast: false

Closes #51

## Test plan
- [ ] Workflow YAML is valid (CI passes)
- [ ] Verified on next version tag push (manual test)

Generated with [Claude Code](https://claude.ai/claude-code)