### PR TITLE
Add rustdoc comments to all public types and modules

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1,30 +1,48 @@
+//! Architectural analysis engine.
+//!
+//! Computes coupling violations and circular dependencies using
+//! bottom-up D_acc aggregation and top-down BFS sibling analysis.
+
 use fxhash::{FxHashMap, FxHashSet};
 use std::collections::BTreeMap;
 
 use crate::core::{Dependency, Module};
 
+/// A detected coupling violation or circular dependency between modules.
 #[derive(Debug, Clone)]
 pub struct CouplingViolation {
+    /// First directory involved in the violation.
     pub dir_a: String,
+    /// Second directory involved in the violation.
     pub dir_b: String,
+    /// Source file containing the problematic import.
     pub from_module: String,
+    /// Target file being imported.
     pub to_module: String,
+    /// Line number of the import in the source file.
     pub line_number: i32,
+    /// Directory depth where the violation occurs.
     pub depth: i32,
+    /// Severity score. Coupling: `1/(depth+1)`. Circular: `modules/(depth+1)/10`.
     pub severity: f64,
+    /// Whether this is a circular dependency (vs. a coupling violation).
     pub is_circular: bool,
-    /// For circular deps: the full cycle path as directory paths
+    /// For circular deps: the full cycle path as directory paths.
     pub cycle_path: Vec<String>,
-    /// For circular deps: the files causing each hop (from_file, to_file, line_number) per edge
+    /// For circular deps: `(from_file, to_file, line_number)` for each hop in the cycle.
     pub cycle_hop_files: Vec<(String, String, i32)>,
-    /// For circular deps: number of nodes in the cycle (2 = mutual, 3 = triangle, etc.)
+    /// For circular deps: number of nodes in the cycle (2 = mutual, 3 = triangle, etc.).
     pub cycle_order: usize,
 }
 
+/// The result of running an architectural audit on a project snapshot.
 #[derive(Debug)]
 pub struct AuditResult {
+    /// All detected violations, sorted by severity descending.
     pub violations: Vec<CouplingViolation>,
+    /// Overall health score (0-100). Higher is better.
     pub score: f64,
+    /// Total number of source modules analyzed.
     pub total_modules: usize,
 }
 

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,5 +1,8 @@
+//! Core domain types shared across all modules.
+
 use serde::{Deserialize, Serialize};
 
+/// Whether a discovered module is a file or directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModuleType {
     #[serde(rename = "FILE")]
@@ -8,28 +11,53 @@ pub enum ModuleType {
     Dir,
 }
 
+/// A source file discovered during scanning.
+///
+/// Represents a single source file with its relative path, name,
+/// and depth within the project tree.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Module {
+    /// Unique identifier (UUID v4).
     pub id: String,
+    /// The snapshot this module belongs to.
     pub snapshot_id: String,
+    /// Parent module ID (unused in current flat structure).
     pub parent_id: Option<String>,
+    /// File name (e.g., `main.rs`).
     pub name: String,
+    /// Relative path from project root (e.g., `src/scanner/parser.rs`).
     pub path: String,
+    /// Whether this is a file or directory.
     pub module_type: ModuleType,
+    /// Depth from the project root (number of path components).
     pub depth: i32,
 }
 
+/// An import dependency between two modules.
+///
+/// Records that `from_module_id` imports something from `to_module_id`
+/// at a specific line number in the source file.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Dependency {
+    /// The module containing the import statement.
     pub from_module_id: String,
+    /// The module being imported.
     pub to_module_id: String,
+    /// Line number of the import statement in the source file.
     pub line_number: i32,
 }
 
+/// A point-in-time scan of a project.
+///
+/// Each scan creates a new snapshot with a unique ID, allowing
+/// historical comparison of architectural health.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Snapshot {
+    /// Unique identifier (UUID v4).
     pub id: String,
+    /// When the snapshot was created (SQLite CURRENT_TIMESTAMP).
     pub timestamp: String,
+    /// The project root path that was scanned.
     pub root_path: String,
 }
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -1,3 +1,8 @@
+//! Source file discovery, Tree-sitter parsing, and import resolution.
+//!
+//! Supports 11 languages: C#, Go, Haskell, Java, JavaScript, Kotlin,
+//! Python, Rust, Swift, TypeScript, and Zig.
+
 mod discovery;
 mod parser;
 mod resolver;
@@ -11,8 +16,11 @@ use anyhow::Result;
 use rayon::prelude::*;
 use std::path::Path;
 
+/// The result of scanning a project directory.
 pub struct ScanResult {
+    /// All discovered source modules.
     pub modules: Vec<Module>,
+    /// All resolved import dependencies between modules.
     pub dependencies: Vec<Dependency>,
 }
 

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -1,14 +1,23 @@
+//! Configuration loaded from `.noupling/settings.json`.
+
 use anyhow::Result;
 use globset::{Glob, GlobSet, GlobSetBuilder};
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
+/// Project settings loaded from `.noupling/settings.json`.
+///
+/// Auto-created with defaults on first run. All fields have defaults,
+/// so partial JSON files are supported.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Settings {
+    /// Score and severity thresholds.
     #[serde(default = "default_thresholds")]
     pub thresholds: Thresholds,
+    /// Glob patterns for directories/files to ignore (gitignore-style).
     #[serde(default = "default_ignore_patterns")]
     pub ignore_patterns: Vec<String>,
+    /// File extensions to include in the scan.
     #[serde(default = "default_source_extensions")]
     pub source_extensions: Vec<String>,
 }

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -2,7 +2,12 @@ use anyhow::Result;
 use rusqlite::Connection;
 use std::path::Path;
 
+/// SQLite database connection with auto-initialized schema.
+///
+/// Creates the `.noupling/history.db` file and initializes
+/// the snapshots, modules, and dependencies tables on first access.
 pub struct Database {
+    /// The underlying SQLite connection.
     pub conn: Connection,
 }
 

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,3 +1,5 @@
+//! SQLite persistence layer for snapshots, modules, and dependencies.
+
 mod db;
 pub mod repository;
 

--- a/src/storage/repository.rs
+++ b/src/storage/repository.rs
@@ -3,6 +3,7 @@ use rusqlite::Connection;
 
 use crate::core::{Dependency, Module, ModuleType, Snapshot};
 
+/// Repository for creating and querying scan snapshots.
 pub struct SnapshotRepository<'a> {
     conn: &'a Connection,
 }
@@ -65,6 +66,7 @@ impl<'a> SnapshotRepository<'a> {
     }
 }
 
+/// Repository for bulk inserting and querying source modules.
 pub struct ModuleRepository<'a> {
     conn: &'a Connection,
 }
@@ -148,6 +150,7 @@ impl<'a> ModuleRepository<'a> {
     }
 }
 
+/// Repository for bulk inserting and querying import dependencies.
 pub struct DependencyRepository<'a> {
     conn: &'a Connection,
 }


### PR DESCRIPTION
## Summary

Adds `///` doc comments to all public types, structs, enums, and fields.
Adds `//!` module-level docs to core, analyzer, scanner, storage, and settings.

`cargo doc --no-deps` builds with zero warnings.

Closes #46
Closes #49

## Test plan
- [ ] `cargo doc --no-deps` produces no warnings
- [ ] All tests pass
- [ ] Clippy clean

Generated with [Claude Code](https://claude.ai/claude-code)