### PR TITLE
Add architecture.md and polish CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,16 +26,38 @@ cargo run -- audit /path/to/project
 cargo run -- report /path/to/project --format html
 ```
 
+## Branching Strategy
+
+- **`main`** is the stable branch. All PRs target `main`.
+- Create feature branches from `main`: `feature/<issue-number>-short-description`
+- One branch per issue. Reference the issue in your PR.
+- PRs are squash-merged to keep history clean.
+
+```bash
+git checkout main
+git pull
+git checkout -b feature/42-add-ruby-parser
+# ... make changes ...
+git push -u origin feature/42-add-ruby-parser
+gh pr create
+```
+
 ## Coding Standards
 
 - **Format**: Run `cargo fmt` before committing.
-- **Lint**: Run `cargo clippy` and fix all warnings.
-- **TDD**: Write tests first when adding new functionality.
-- **Commits**: Use conventional commit messages (`feat:`, `fix:`, `docs:`, `refactor:`, `chore:`).
+- **Lint**: Run `cargo clippy -- -D warnings` and fix all warnings. CI enforces zero warnings.
+- **TDD**: Write tests first when adding new functionality (Red-Green-Refactor).
+- **Commits**: Use conventional commit messages:
+  - `feat(scanner): add Ruby parser (#42)`
+  - `fix(analyzer): correct severity at depth 0`
+  - `docs: update architecture diagram`
+  - `refactor(storage): simplify query builder`
+  - `chore: bump tree-sitter to 0.26`
+- **CI must pass**: Check, format, clippy, and tests on Linux/macOS/Windows.
 
 ## Architecture
 
-The project uses a flat module structure inside `src/`:
+See [docs/architecture.md](docs/architecture.md) for the full data flow and module responsibilities.
 
 ```
 src/
@@ -52,30 +74,64 @@ src/
 
 ## Adding a New Language Parser
 
-1. Add the `tree-sitter-<lang>` dependency to `Cargo.toml`.
-2. Add the file extension to `SOURCE_EXTENSIONS` in `settings.rs` (default list).
-3. In `src/scanner/parser.rs`:
-   - Add a `parse_<lang>_imports()` function using tree-sitter.
-   - Add tests for the parser.
-4. In `src/scanner/resolver.rs`:
-   - Add a `resolve_<lang>_import()` function.
-   - Add the extension to the `match` in `resolve_import()`.
-   - Add resolver tests.
-5. In `src/scanner/mod.rs`:
-   - Add the extension to the `match` in `scan_project()`.
-6. Run `cargo test` and `cargo clippy`.
+This is the most common contribution. Follow these steps:
+
+1. **Add dependency** to `Cargo.toml`:
+   ```toml
+   tree-sitter-ruby = "0.23"
+   ```
+
+2. **Add extension** to `default_source_extensions()` in `src/settings.rs`:
+   ```rust
+   "rb".to_string(),
+   ```
+
+3. **Add parser** in `src/scanner/parser.rs`:
+   ```rust
+   pub fn parse_ruby_imports(source: &str) -> Vec<ImportEntry> {
+       // Use tree-sitter to parse imports
+   }
+   ```
+   Add at least 3 tests: simple import, multiple imports, empty source.
+
+4. **Add resolver** in `src/scanner/resolver.rs`:
+   ```rust
+   fn resolve_ruby_import(import_path: &str, known_paths: &[String]) -> Option<String> {
+       // Map import to project file path
+   }
+   ```
+   Add the extension to the `match` in `resolve_import()`. Add resolver tests.
+
+5. **Route in scanner** in `src/scanner/mod.rs`:
+   ```rust
+   "rb" => parser::parse_ruby_imports(&source),
+   ```
+
+6. **Update README.md** supported languages list.
+
+7. **Verify**:
+   ```bash
+   cargo test
+   cargo clippy -- -D warnings
+   cargo fmt --check
+   ```
 
 ## Submitting a Pull Request
 
-1. Fork the repository and create a feature branch.
+1. Fork the repository and create a feature branch from `main`.
 2. Make your changes following the coding standards above.
-3. Ensure all tests pass: `cargo test`
-4. Ensure no clippy warnings: `cargo clippy`
-5. Ensure code is formatted: `cargo fmt --check`
-6. Open a PR with a clear description of what changed and why.
+3. Ensure all checks pass locally:
+   ```bash
+   cargo test
+   cargo clippy -- -D warnings
+   cargo fmt --check
+   ```
+4. Push and open a PR with a clear description.
+5. Reference the GitHub Issue: `Closes #42`.
+6. Wait for CI to pass on all platforms.
 
 ## Reporting Issues
 
-- Use the GitHub issue templates for bug reports and feature requests.
+- Use the [bug report](https://github.com/pererikbergman/noupling/issues/new?template=bug_report.md) or [feature request](https://github.com/pererikbergman/noupling/issues/new?template=feature_request.md) templates.
 - Include the output of `noupling --version` and the command you ran.
 - For scan issues, include the language and a minimal reproducible example.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,78 @@
+# Architecture
+
+## Overview
+
+noupling is a single Rust binary that scans source code, extracts import dependencies, and analyzes architectural coupling. The data flows through four stages:
+
+```
+scan -> store -> analyze -> report
+```
+
+## Data Flow
+
+```
+1. SCAN          2. STORE           3. ANALYZE         4. REPORT
++-----------+    +-----------+     +------------+     +-----------+
+| scanner/  | -> | storage/  | --> | analyzer/  | --> | reporter/ |
+|           |    |           |     |            |     |           |
+| discover  |    | SQLite DB |     | D_acc      |     | JSON      |
+| parse     |    | snapshots |     | BFS audit  |     | XML       |
+| resolve   |    | modules   |     | cycles     |     | Markdown  |
+|           |    | deps      |     | score      |     | HTML      |
++-----------+    +-----------+     +------------+     | Sonar     |
+                                                      +-----------+
+```
+
+## Module Responsibilities
+
+### `src/core/`
+Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `Snapshot`. These are the data structures that flow between stages.
+
+### `src/scanner/`
+**Stage 1: Scan.** Discovers source files, parses them with Tree-sitter, and resolves import paths.
+
+- `discovery.rs` - Recursive file walker. Filters by `source_extensions` and `ignore_patterns` from settings. Produces `Module` structs with relative paths.
+- `parser.rs` - Tree-sitter parsers for 11 languages. Each `parse_<lang>_imports()` function extracts import statements with line numbers.
+- `resolver.rs` - Maps parsed imports to actual file paths in the project. Language-specific resolution (Rust `crate::`, Kotlin dot-separated, TypeScript relative, etc.).
+- `mod.rs` - Orchestrates: discover files, parse imports in parallel (Rayon), resolve to dependencies.
+
+### `src/storage/`
+**Stage 2: Store.** SQLite persistence in `.noupling/history.db`.
+
+- `db.rs` - `Database` struct. Auto-creates schema (snapshots, modules, dependencies tables) on first access.
+- `repository.rs` - `SnapshotRepository`, `ModuleRepository`, `DependencyRepository`. Each provides CRUD operations with parameterized queries.
+
+### `src/analyzer/`
+**Stage 3: Analyze.** The core algorithm.
+
+- **D_acc (Accumulated Dependencies):** For each directory, computes the union of all external dependencies from its subtree. Internal dependencies (within the same directory) are excluded.
+- **BFS Coupling Detection:** Walks the directory tree top-down. At each level, checks sibling pairs: if D_acc(A) references a module inside B, that's a coupling violation.
+- **Circular Dependency Detection:** At each BFS level, builds a graph between siblings using D_acc and finds all elementary cycles via DFS.
+- **Severity:** Coupling = `1/(depth+1)`. Circular = `modules/(depth+1)/10`.
+- **Health Score:** `100 * (1 - sum_severity / total_modules)`.
+
+### `src/reporter/`
+**Stage 4: Report.** Generates output in 6 formats.
+
+- `mod.rs` - JSON report (comprehensive with directory tree), XML, SonarCloud, and text format.
+- `html.rs` - Multi-file static HTML with Kover-style drill-down navigation.
+- `md.rs` - Multi-file Markdown with navigable README.md per directory.
+
+### `src/cli.rs`
+Clap argument parsing. Commands: `init`, `scan`, `audit`, `report`.
+
+### `src/settings.rs`
+Loads `.noupling/settings.json` with thresholds, ignore patterns, and source extensions. Falls back to defaults if missing.
+
+### `src/diff.rs`
+Git integration for PR/CI mode. Shells out to `git diff --name-only <base>...HEAD` to get changed files.
+
+## Key Design Decisions
+
+1. **Forward slashes everywhere.** All paths are normalized to `/` regardless of OS. This ensures SQLite data and reports are portable.
+
+2. **Scan everything, filter violations.** In diff mode, the full project is scanned (needed for import resolution), but only violations involving changed files are reported.
+
+3. **Circular detection at sibling level.** Cycles are detected per BFS level using D_acc, not on the raw file dependency graph. This shows cycles at the directory level where they're actionable.
+
+4. **Settings auto-created.** If `.noupling/settings.json` doesn't exist, it's created with defaults on any command. This avoids a mandatory init step.


### PR DESCRIPTION
## Summary

- **docs/architecture.md**: Data flow diagram, module responsibilities, key design decisions
- **CONTRIBUTING.md**: Branching strategy, expanded language parser guide with code examples, architecture link, issue template links

Closes #47
Closes #48

## Test plan
- [ ] architecture.md accurately reflects current codebase
- [ ] CONTRIBUTING.md steps work on a clean checkout

Generated with [Claude Code](https://claude.ai/claude-code)