### PR TITLE
Homebrew tap infrastructure

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,0 +1,35 @@
+name: Update Homebrew
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  update-formula:
+    name: Update Homebrew Formula
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+
+      - name: Calculate SHA256
+        id: sha
+        run: |
+          SHA=$(curl -sL "https://github.com/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz" | sha256sum | awk '{print $1}')
+          echo "sha256=$SHA" >> $GITHUB_OUTPUT
+
+      - name: Update formula
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          repository: pererikbergman/homebrew-noupling
+          event-type: update-formula
+          client-payload: |
+            {
+              "version": "${{ steps.version.outputs.version }}",
+              "sha256": "${{ steps.sha.outputs.sha256 }}",
+              "tag": "${{ github.ref_name }}"
+            }

--- a/README.md
+++ b/README.md
@@ -60,6 +60,13 @@ noupling report /path/to/project --format html
 
 ## Installation
 
+### Homebrew (macOS/Linux)
+
+```bash
+brew tap pererikbergman/noupling
+brew install noupling
+```
+
 ### From source
 
 ```bash

--- a/scripts/update-homebrew.sh
+++ b/scripts/update-homebrew.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+# Usage: ./scripts/update-homebrew.sh <version>
+# Example: ./scripts/update-homebrew.sh 0.1.0
+#
+# Downloads the source tarball, calculates SHA256, and updates
+# the Homebrew formula in the homebrew-noupling tap repo.
+
+VERSION="${1:-}"
+
+if [[ -z "$VERSION" ]]; then
+    echo "Usage: $0 <version>"
+    echo "Example: $0 0.1.0"
+    exit 1
+fi
+
+TAG="v${VERSION}"
+TARBALL_URL="https://github.com/pererikbergman/noupling/archive/refs/tags/${TAG}.tar.gz"
+TAP_REPO="pererikbergman/homebrew-noupling"
+FORMULA_PATH="Formula/noupling.rb"
+
+echo "Updating Homebrew formula for ${TAG}..."
+
+# Download tarball and calculate SHA256
+echo "Downloading ${TARBALL_URL}..."
+SHA256=$(curl -sL "${TARBALL_URL}" | shasum -a 256 | awk '{print $1}')
+
+if [[ -z "$SHA256" || "$SHA256" == "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855" ]]; then
+    echo "Error: Failed to download tarball or tag ${TAG} does not exist."
+    exit 1
+fi
+
+echo "SHA256: ${SHA256}"
+
+# Clone the tap repo
+TMPDIR=$(mktemp -d)
+cd "${TMPDIR}"
+gh repo clone "${TAP_REPO}" tap
+cd tap
+
+# Update the formula
+sed -i '' "s|url \".*\"|url \"${TARBALL_URL}\"|" "${FORMULA_PATH}"
+sed -i '' "s|sha256 \".*\"|sha256 \"${SHA256}\"|" "${FORMULA_PATH}"
+
+echo ""
+echo "Updated formula:"
+cat "${FORMULA_PATH}"
+
+# Commit and push
+git add "${FORMULA_PATH}"
+git commit -m "Update noupling to ${VERSION}"
+git push
+
+echo ""
+echo "Homebrew formula updated to ${VERSION}"
+echo "Users can now run: brew upgrade noupling"
+
+# Cleanup
+rm -rf "${TMPDIR}"


### PR DESCRIPTION
## Summary

Sets up Homebrew tap for `brew install noupling`:

- **Tap repo**: [homebrew-noupling](https://github.com/pererikbergman/homebrew-noupling) with `Formula/noupling.rb`
- **Manual script**: `scripts/update-homebrew.sh <version>` downloads tarball, calculates SHA256, updates formula
- **Auto workflow**: `.github/workflows/homebrew.yml` triggers on release publish, dispatches to tap repo

### Usage (after first release)
```bash
brew tap pererikbergman/noupling
brew install noupling
```

### Note
The formula currently has a placeholder SHA256. It will be updated automatically on the first tagged release, or manually via `./scripts/update-homebrew.sh 0.1.0`.

The auto-update workflow requires a `HOMEBREW_TAP_TOKEN` secret with repo access to `homebrew-noupling`.

Closes #42
Closes #43
Closes #44
Closes #45

## Test plan
- [ ] Tap repo has valid formula structure
- [ ] `update-homebrew.sh` shows usage on no args
- [ ] Workflow YAML is valid

Generated with [Claude Code](https://claude.ai/claude-code)