### PR TITLE
Add --fail-below threshold for CI gating

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,12 @@ noupling audit /path/to/project
 
 Displays a health score (0-100), coupling violations sorted by severity, and circular dependencies grouped by cycle order.
 
+Use `--fail-below` to fail in CI when the score drops:
+
+```bash
+noupling audit /path/to/project --fail-below 80  # Exit code 1 if score < 80
+```
+
 ### Generate reports
 
 ```bash
@@ -133,8 +139,8 @@ Scans the full project for import resolution but filters results to changed file
 - name: Scan (diff mode)
   run: noupling scan . --diff-base origin/main
 
-- name: Audit
-  run: noupling audit .
+- name: Audit (fail if score drops below 80)
+  run: noupling audit . --fail-below 80
 
 - name: Generate Sonar report
   run: noupling report . --format sonar

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -98,6 +98,11 @@ pub enum Commands {
         /// Audit a specific snapshot by ID instead of the latest one
         #[arg(long)]
         snapshot: Option<String>,
+
+        /// Exit with code 1 if health score is below this threshold.
+        /// Use in CI to gate merges: --fail-below 80
+        #[arg(long)]
+        fail_below: Option<f64>,
     },
 
     /// Generate a report file from the latest snapshot's audit results.
@@ -140,9 +145,14 @@ mod tests {
     fn parse_audit_command_no_snapshot() {
         let cli = Cli::parse_from(["noupling", "audit"]);
         match cli.command {
-            Commands::Audit { snapshot, path } => {
+            Commands::Audit {
+                snapshot,
+                path,
+                fail_below,
+            } => {
                 assert!(snapshot.is_none());
                 assert_eq!(path, ".");
+                assert!(fail_below.is_none());
             }
             _ => panic!("Expected Audit command"),
         }
@@ -153,6 +163,15 @@ mod tests {
         let cli = Cli::parse_from(["noupling", "audit", "--snapshot", "abc-123"]);
         match cli.command {
             Commands::Audit { snapshot, .. } => assert_eq!(snapshot, Some("abc-123".to_string())),
+            _ => panic!("Expected Audit command"),
+        }
+    }
+
+    #[test]
+    fn parse_audit_with_fail_below() {
+        let cli = Cli::parse_from(["noupling", "audit", "--fail-below", "80"]);
+        match cli.command {
+            Commands::Audit { fail_below, .. } => assert_eq!(fail_below, Some(80.0)),
             _ => panic!("Expected Audit command"),
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,7 +31,11 @@ fn main() {
     let result = match cli.command {
         Commands::Init { path } => run_init(&path),
         Commands::Scan { path, diff_base } => run_scan(&path, diff_base.as_deref()),
-        Commands::Audit { path, snapshot } => run_audit(&path, snapshot.as_deref()),
+        Commands::Audit {
+            path,
+            snapshot,
+            fail_below,
+        } => run_audit(&path, snapshot.as_deref(), fail_below),
         Commands::Report { path, format } => run_report(&path, &format),
     };
 
@@ -153,7 +157,7 @@ fn run_scan(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_audit(path: &str, snapshot_id: Option<&str>) -> anyhow::Result<()> {
+fn run_audit(path: &str, snapshot_id: Option<&str>, fail_below: Option<f64>) -> anyhow::Result<()> {
     let db = find_db(path)?;
     let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
 
@@ -182,6 +186,16 @@ fn run_audit(path: &str, snapshot_id: Option<&str>) -> anyhow::Result<()> {
     }
 
     print!("{}", reporter::format_text(&result));
+
+    if let Some(threshold) = fail_below {
+        if result.score < threshold {
+            anyhow::bail!(
+                "Health score {:.1} is below threshold {:.1}",
+                result.score,
+                threshold
+            );
+        }
+    }
 
     Ok(())
 }


### PR DESCRIPTION
## Summary

Adds `--fail-below <score>` flag to the audit command. Exits with code 1 if the health score is below the threshold.

```bash
noupling audit . --fail-below 80  # Fails if score < 80
```

Use in CI to gate merges when architecture degrades.

Closes #72

## Test plan
- [x] `--fail-below 50` passes on this project (score 88.8)
- [x] `--fail-below 99` fails on this project (score 88.8)
- [x] No flag = always exit 0 (no behavior change)
- [x] New CLI test for flag parsing
- [x] 142 tests passing, zero clippy warnings

Generated with [Claude Code](https://claude.ai/claude-code)