### PR TITLE
Baseline file for incremental violation tracking

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -100,7 +100,7 @@ impl AuditResult {
         self.recalculate_score();
     }
 
-    fn recalculate_score(&mut self) {
+    pub fn recalculate_score(&mut self) {
         let sum_severity: f64 = self.violations.iter().map(|v| v.severity).sum();
         self.score = if self.total_modules > 0 {
             (100.0 * (1.0 - sum_severity / self.total_modules as f64)).max(0.0)

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -1,0 +1,219 @@
+//! Baseline file management for incremental adoption.
+//!
+//! Saves current violations as an accepted baseline. Future audits with
+//! `--baseline` only report violations not in the baseline.
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::HashSet;
+use std::path::Path;
+
+use crate::analyzer::{AuditResult, CouplingViolation};
+
+/// A fingerprint that uniquely identifies a violation.
+fn fingerprint(v: &CouplingViolation) -> String {
+    if v.is_circular {
+        let dirs: Vec<String> = v
+            .cycle_path
+            .iter()
+            .map(|p| {
+                std::path::Path::new(p)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(p)
+                    .to_string()
+            })
+            .collect();
+        format!("circular:{}:{}", v.cycle_order, dirs.join("->"))
+    } else {
+        format!("coupling:{}:{}", v.from_module, v.to_module)
+    }
+}
+
+#[derive(Serialize, Deserialize)]
+struct BaselineFile {
+    version: u32,
+    timestamp: String,
+    violation_count: usize,
+    fingerprints: Vec<String>,
+}
+
+/// Save current violations as the baseline.
+pub fn save_baseline(path: &Path, result: &AuditResult) -> Result<()> {
+    let fingerprints: Vec<String> = result.violations.iter().map(fingerprint).collect();
+
+    let baseline = BaselineFile {
+        version: 1,
+        timestamp: chrono_now(),
+        violation_count: fingerprints.len(),
+        fingerprints,
+    };
+
+    let content = serde_json::to_string_pretty(&baseline)?;
+    let baseline_path = path.join(".noupling").join("baseline.json");
+    std::fs::create_dir_all(path.join(".noupling"))?;
+    std::fs::write(&baseline_path, content)?;
+    println!(
+        "Baseline saved with {} violations to {}",
+        baseline.violation_count,
+        baseline_path.display()
+    );
+    Ok(())
+}
+
+/// Compare current violations against the baseline.
+/// Returns (new_violations, resolved_count).
+pub fn compare_baseline(path: &Path, result: &mut AuditResult) -> Result<(usize, usize)> {
+    let baseline_path = path.join(".noupling").join("baseline.json");
+    if !baseline_path.exists() {
+        anyhow::bail!(
+            "No baseline found at {}. Run `noupling baseline save` first.",
+            baseline_path.display()
+        );
+    }
+
+    let content = std::fs::read_to_string(&baseline_path)?;
+    let baseline: BaselineFile = serde_json::from_str(&content)?;
+    let baseline_set: HashSet<String> = baseline.fingerprints.into_iter().collect();
+
+    // Partition violations into new (not in baseline) and existing (in baseline)
+    let mut new_count = 0;
+    let current_fingerprints: Vec<String> = result.violations.iter().map(fingerprint).collect();
+
+    // Count resolved (in baseline but not in current)
+    let current_set: HashSet<String> = current_fingerprints.iter().cloned().collect();
+    let resolved_count = baseline_set
+        .iter()
+        .filter(|f| !current_set.contains(*f))
+        .count();
+
+    // Keep only new violations
+    result.violations.retain(|v| {
+        let fp = fingerprint(v);
+        let is_new = !baseline_set.contains(&fp);
+        if is_new {
+            new_count += 1;
+        }
+        is_new
+    });
+    result.recalculate_score();
+
+    Ok((new_count, resolved_count))
+}
+
+fn chrono_now() -> String {
+    // Simple timestamp without adding chrono dependency
+    use std::time::SystemTime;
+    let duration = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    format!("{}", duration.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_coupling(from: &str, to: &str) -> CouplingViolation {
+        CouplingViolation {
+            dir_a: "a".to_string(),
+            dir_b: "b".to_string(),
+            from_module: from.to_string(),
+            to_module: to.to_string(),
+            line_number: 1,
+            depth: 0,
+            severity: 0.5,
+            is_circular: false,
+            cycle_path: Vec::new(),
+            cycle_hop_files: Vec::new(),
+            cycle_order: 0,
+        }
+    }
+
+    #[test]
+    fn save_and_compare_baseline() {
+        let dir = tempfile::tempdir().unwrap();
+        let noupling_dir = dir.path().join(".noupling");
+        std::fs::create_dir_all(&noupling_dir).unwrap();
+        // Create a fake history.db so find_db doesn't fail
+        std::fs::write(noupling_dir.join("history.db"), "").unwrap();
+
+        let result = AuditResult {
+            violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
+            score: 50.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+        };
+
+        // Save baseline
+        save_baseline(dir.path(), &result).unwrap();
+        assert!(dir.path().join(".noupling/baseline.json").exists());
+
+        // Same violations = all existing, none new
+        let mut same_result = AuditResult {
+            violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
+            score: 50.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+        };
+        let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
+        assert_eq!(new, 0);
+        assert_eq!(resolved, 0);
+        assert!(same_result.violations.is_empty());
+    }
+
+    #[test]
+    fn detects_new_violations() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".noupling")).unwrap();
+
+        let baseline_result = AuditResult {
+            violations: vec![make_coupling("a.rs", "b.rs")],
+            score: 75.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+        };
+        save_baseline(dir.path(), &baseline_result).unwrap();
+
+        // New violation added
+        let mut current = AuditResult {
+            violations: vec![
+                make_coupling("a.rs", "b.rs"), // existing
+                make_coupling("x.rs", "y.rs"), // new
+            ],
+            score: 50.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+        };
+        let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
+        assert_eq!(new, 1);
+        assert_eq!(resolved, 0);
+        assert_eq!(current.violations.len(), 1);
+        assert_eq!(current.violations[0].from_module, "x.rs");
+    }
+
+    #[test]
+    fn detects_resolved_violations() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".noupling")).unwrap();
+
+        let baseline_result = AuditResult {
+            violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
+            score: 50.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+        };
+        save_baseline(dir.path(), &baseline_result).unwrap();
+
+        // One violation resolved
+        let mut current = AuditResult {
+            violations: vec![make_coupling("a.rs", "b.rs")],
+            score: 75.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+        };
+        let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
+        assert_eq!(new, 0);
+        assert_eq!(resolved, 1);
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -100,6 +100,18 @@ pub enum Commands {
         diff_base: Option<String>,
     },
 
+    /// Save or manage the violation baseline.
+    /// `noupling baseline save .` saves current violations as the accepted baseline.
+    /// Future audits with --baseline will only report NEW violations not in the baseline.
+    Baseline {
+        /// Action: "save" to create baseline from current violations
+        action: String,
+
+        /// Path to the project root
+        #[arg(default_value = ".")]
+        path: String,
+    },
+
     /// Run the coupling and circular dependency analysis on the latest (or specified) snapshot.
     /// Displays health score, violation count, and detailed violation list to stdout.
     Audit {
@@ -115,6 +127,11 @@ pub enum Commands {
         /// Use in CI to gate merges: --fail-below 80
         #[arg(long)]
         fail_below: Option<f64>,
+
+        /// Compare against the saved baseline. Only report NEW violations
+        /// not in .noupling/baseline.json. Exit code 1 only on new violations.
+        #[arg(long)]
+        baseline: bool,
     },
 
     /// Generate a report file from the latest snapshot's audit results.
@@ -161,9 +178,11 @@ mod tests {
                 snapshot,
                 path,
                 fail_below,
+                baseline,
             } => {
                 assert!(snapshot.is_none());
                 assert_eq!(path, ".");
+                assert!(!baseline);
                 assert!(fail_below.is_none());
             }
             _ => panic!("Expected Audit command"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 mod analyzer;
+mod baseline;
 mod cli;
 mod core;
 mod diff;
@@ -21,6 +22,7 @@ fn main() {
         Commands::Init { path }
         | Commands::Scan { path, .. }
         | Commands::Hook { path, .. }
+        | Commands::Baseline { path, .. }
         | Commands::Audit { path, .. }
         | Commands::Report { path, .. } => {
             let settings_path = Path::new(path).join(".noupling").join("settings.json");
@@ -34,11 +36,13 @@ fn main() {
         Commands::Init { path } => run_init(&path),
         Commands::Hook { action, path } => run_hook(&action, &path),
         Commands::Scan { path, diff_base } => run_scan(&path, diff_base.as_deref()),
+        Commands::Baseline { action, path } => run_baseline(&action, &path),
         Commands::Audit {
             path,
             snapshot,
             fail_below,
-        } => run_audit(&path, snapshot.as_deref(), fail_below),
+            baseline,
+        } => run_audit(&path, snapshot.as_deref(), fail_below, baseline),
         Commands::Report { path, format } => run_report(&path, &format),
     };
 
@@ -171,7 +175,39 @@ fn run_scan(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
     Ok(())
 }
 
-fn run_audit(path: &str, snapshot_id: Option<&str>, fail_below: Option<f64>) -> anyhow::Result<()> {
+fn run_baseline(action: &str, path: &str) -> anyhow::Result<()> {
+    match action {
+        "save" => {
+            let db = find_db(path)?;
+            let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
+            let snapshot = snap_repo
+                .get_latest()?
+                .ok_or_else(|| anyhow::anyhow!("No snapshots found. Run `noupling scan` first."))?;
+
+            let module_repo = storage::repository::ModuleRepository::new(&db.conn);
+            let dep_repo = storage::repository::DependencyRepository::new(&db.conn);
+            let modules = module_repo.get_by_snapshot(&snapshot.id)?;
+            let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
+
+            let project_settings = settings::Settings::load(Path::new(path))?;
+            let mut result = analyzer::audit(&modules, &dependencies);
+            result.filter_by_severity(project_settings.thresholds.minimum_severity);
+
+            baseline::save_baseline(Path::new(path), &result)?;
+        }
+        _ => {
+            anyhow::bail!("Unknown baseline action: {}. Use 'save'.", action);
+        }
+    }
+    Ok(())
+}
+
+fn run_audit(
+    path: &str,
+    snapshot_id: Option<&str>,
+    fail_below: Option<f64>,
+    use_baseline: bool,
+) -> anyhow::Result<()> {
     let db = find_db(path)?;
     let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
 
@@ -199,7 +235,24 @@ fn run_audit(path: &str, snapshot_id: Option<&str>, fail_below: Option<f64>) -> 
         result.filter_by_changed_files(&changed_files);
     }
 
+    // Apply baseline filter
+    let baseline_info = if use_baseline {
+        let (new_count, resolved_count) = baseline::compare_baseline(Path::new(path), &mut result)?;
+        Some((new_count, resolved_count))
+    } else {
+        None
+    };
+
     print!("{}", reporter::format_text(&result));
+
+    if let Some((new_count, resolved_count)) = baseline_info {
+        println!("\nBaseline comparison:");
+        println!("  New violations: {}", new_count);
+        println!("  Resolved violations: {}", resolved_count);
+        if new_count > 0 {
+            anyhow::bail!("{} new violation(s) introduced since baseline", new_count);
+        }
+    }
 
     if let Some(threshold) = fail_below {
         if result.score < threshold {


### PR DESCRIPTION
## Summary

Adds baseline support for incremental adoption. Teams can save current violations and only fail on new ones.

**New commands:**
- `noupling baseline save .` - saves current violations to `.noupling/baseline.json`
- `noupling audit . --baseline` - only reports NEW violations not in the baseline

**How it works:**
- Violations are fingerprinted by `(from_module, to_module)` for coupling and `(cycle_order, dir_names)` for circular
- Baseline comparison partitions violations into new (not in baseline) and resolved (in baseline but gone)
- Exit code 1 only when new violations exist
- Resolved violations shown as positive feedback

Closes #74

## Test plan
- [x] 145 tests passing (3 new baseline tests)
- [x] Zero clippy warnings
- [x] Save baseline creates valid JSON
- [x] Same violations = 0 new, 0 resolved
- [x] New violation detected correctly
- [x] Resolved violation counted correctly

Generated with [Claude Code](https://claude.ai/claude-code)