### PR TITLE
Dependency weight for coupling violations

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -23,7 +23,9 @@ pub struct CouplingViolation {
     pub line_number: i32,
     /// Directory depth where the violation occurs.
     pub depth: i32,
-    /// Severity score. Coupling: `1/(depth+1)`. Circular: `modules/(depth+1)/10`.
+    /// Number of import statements between this directory pair.
+    pub weight: usize,
+    /// Severity score. Coupling: `weight/(depth+1)`. Circular: `modules/(depth+1)/10`.
     pub severity: f64,
     /// Whether this is a circular dependency (vs. a coupling violation).
     pub is_circular: bool,
@@ -492,9 +494,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
                 to_module: last_target.clone(),
                 line_number: 0,
                 depth,
-                // Circular deps scale inversely with depth:
-                // Root level (depth 0): severity = total_modules (can zero the score)
-                // Deeper: severity = total_modules / (depth + 1)
+                weight: 0,
                 severity: modules.len() as f64 / (depth as f64 + 1.0) / 10.0,
                 is_circular: true,
                 cycle_path: cycle.dir_path.clone(),
@@ -537,6 +537,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
                                                         .to_string(),
                                                     line_number: dep.line_number,
                                                     depth,
+                                                    weight: 1,
                                                     severity: 1.0 / (depth as f64 + 1.0),
                                                     is_circular: false,
                                                     cycle_path: Vec::new(),
@@ -577,6 +578,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
                                                         .to_string(),
                                                     line_number: dep.line_number,
                                                     depth,
+                                                    weight: 1,
                                                     severity: 1.0 / (depth as f64 + 1.0),
                                                     is_circular: false,
                                                     cycle_path: Vec::new(),
@@ -595,13 +597,34 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         }
     }
 
+    // Aggregate coupling violations by (dir_a, dir_b, depth) and count weight
+    let mut weight_map: FxHashMap<(String, String, i32), usize> = FxHashMap::default();
+    for v in &violations {
+        if !v.is_circular {
+            let key = (v.dir_a.clone(), v.dir_b.clone(), v.depth);
+            *weight_map.entry(key).or_insert(0) += 1;
+        }
+    }
+
+    // Dedup coupling violations, keeping one per (dir_a, dir_b, depth) with weight
+    let mut seen: FxHashSet<(String, String, i32)> = FxHashSet::default();
+    violations.retain_mut(|v| {
+        if v.is_circular {
+            return true;
+        }
+        let key = (v.dir_a.clone(), v.dir_b.clone(), v.depth);
+        if seen.contains(&key) {
+            return false;
+        }
+        seen.insert(key.clone());
+        let w = *weight_map.get(&key).unwrap_or(&1);
+        v.weight = w;
+        v.severity = w as f64 / (v.depth as f64 + 1.0);
+        true
+    });
+
     // Sort by severity descending
     violations.sort_by(|a, b| b.severity.partial_cmp(&a.severity).unwrap());
-
-    // Dedup violations (same from_module + to_module pair at same depth)
-    violations.dedup_by(|a, b| {
-        a.from_module == b.from_module && a.to_module == b.to_module && a.depth == b.depth
-    });
 
     // Health score
     let sum_severity: f64 = violations.iter().map(|v| v.severity).sum();

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -121,6 +121,7 @@ mod tests {
             from_module: from.to_string(),
             to_module: to.to_string(),
             line_number: 1,
+            weight: 1,
             depth: 0,
             severity: 0.5,
             is_circular: false,

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -844,6 +844,7 @@ mod tests {
                 cycle_hop_files: Vec::new(),
                 cycle_order: 0,
                 line_number: 0,
+                weight: 0,
             }],
             score: 75.0,
             total_modules: 2,

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -52,6 +52,7 @@ pub struct JsonHopFile {
 #[derive(Serialize)]
 pub struct JsonCouplingViolation {
     pub severity: f64,
+    pub weight: usize,
     pub from_module: String,
     pub to_module: String,
     pub dir_a: String,
@@ -149,6 +150,7 @@ impl JsonReport {
             .iter()
             .map(|v| JsonCouplingViolation {
                 severity: v.severity,
+                weight: v.weight,
                 from_module: v.from_module.clone(),
                 to_module: v.to_module.clone(),
                 dir_a: v.dir_a.clone(),
@@ -574,7 +576,13 @@ pub fn format_text(result: &AuditResult) -> String {
     if !result.violations.is_empty() {
         output.push('\n');
         for v in &result.violations {
-            let label = if v.is_circular { " CIRCULAR" } else { "" };
+            let label = if v.is_circular {
+                " CIRCULAR".to_string()
+            } else if v.weight > 1 {
+                format!(" x{}", v.weight)
+            } else {
+                String::new()
+            };
             output.push_str(&format!(
                 "  [{:.2}]{} {} -> {} (depth {})\n",
                 v.severity, label, v.from_module, v.to_module, v.depth
@@ -749,6 +757,7 @@ mod tests {
             cycle_hop_files: Vec::new(),
             cycle_order: 0,
             line_number: 0,
+            weight: 0,
         }
     }
 


### PR DESCRIPTION
## Summary

Counts import statements per directory pair and uses weight as severity multiplier:
`severity = weight / (depth + 1)`

A module with 5 imports into a sibling is 5x more severe than one with 1.

- `weight` field on CouplingViolation
- Audit output: `[1.67 x5] scanner -> core (depth 2)`
- JSON report includes `weight` per coupling violation
- Violations aggregated by (dir_a, dir_b, depth) before scoring

Closes #65

## Test plan
- [x] 149 tests passing
- [x] Zero clippy warnings
- [x] Weight computed and displayed correctly

Generated with [Claude Code](https://claude.ai/claude-code)