### PR TITLE
Install dev version alongside production (noupling-dev)

### DIFF
--- a/scripts/install-dev.sh
+++ b/scripts/install-dev.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install noupling as noupling-dev alongside the stable production binary.
+# Usage: ./scripts/install-dev.sh
+
+echo "Building noupling from current branch..."
+cargo build --release
+
+# Get version + git hash for dev identification
+VERSION=$(grep '^version = ' Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+GIT_HASH=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+BRANCH=$(git branch --show-current 2>/dev/null || echo "unknown")
+
+# Copy as noupling-dev
+DEST="${CARGO_HOME:-$HOME/.cargo}/bin/noupling-dev"
+cp target/release/noupling "$DEST"
+chmod +x "$DEST"
+
+echo ""
+echo "Installed as: noupling-dev"
+echo "Version: $VERSION ($BRANCH @ $GIT_HASH)"
+echo "Location: $DEST"
+echo ""
+echo "You now have both:"
+echo "  noupling     - stable production version"
+echo "  noupling-dev - development build from $BRANCH"


### PR DESCRIPTION
## Summary

Adds `./scripts/install-dev.sh` that builds from current branch and installs as `noupling-dev`, keeping the stable `noupling` binary untouched.

```bash
./scripts/install-dev.sh
# Installed as: noupling-dev
# Version: 0.2.0 (feature/my-branch @ abc1234)
```

Now you have both:
- `noupling` - stable production
- `noupling-dev` - latest from your branch

Closes #103

## Test plan
- [x] Script builds and copies binary
- [x] Both binaries coexist

Generated with [Claude Code](https://claude.ai/claude-code)