### PR TITLE
Trend command for score history across snapshots

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -134,6 +134,17 @@ pub enum Commands {
         baseline: bool,
     },
 
+    /// Show health score history across snapshots. Track architectural drift over time.
+    Trend {
+        /// Path to the project root (reads from .noupling/history.db)
+        #[arg(default_value = ".")]
+        path: String,
+
+        /// Show only the last N snapshots
+        #[arg(long, default_value = "20")]
+        last: usize,
+    },
+
     /// Generate a report file from the latest snapshot's audit results.
     /// The report is saved to .noupling/ (or .noupling/report/ for html/md).
     Report {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ fn main() {
         | Commands::Hook { path, .. }
         | Commands::Baseline { path, .. }
         | Commands::Audit { path, .. }
+        | Commands::Trend { path, .. }
         | Commands::Report { path, .. } => {
             let settings_path = Path::new(path).join(".noupling").join("settings.json");
             if !settings_path.exists() {
@@ -43,6 +44,7 @@ fn main() {
             fail_below,
             baseline,
         } => run_audit(&path, snapshot.as_deref(), fail_below, baseline),
+        Commands::Trend { path, last } => run_trend(&path, last),
         Commands::Report { path, format } => run_report(&path, &format),
     };
 
@@ -90,6 +92,83 @@ fn run_hook(action: &str, path: &str) -> anyhow::Result<()> {
             action
         ),
     }
+}
+
+fn run_trend(path: &str, last: usize) -> anyhow::Result<()> {
+    let db = find_db(path)?;
+    let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
+    let module_repo = storage::repository::ModuleRepository::new(&db.conn);
+    let dep_repo = storage::repository::DependencyRepository::new(&db.conn);
+
+    let project_settings = settings::Settings::load(Path::new(path))?;
+    let snapshots = snap_repo.get_all()?;
+
+    if snapshots.is_empty() {
+        println!("No snapshots found. Run `noupling scan` first.");
+        return Ok(());
+    }
+
+    let display_snapshots = if snapshots.len() > last {
+        &snapshots[snapshots.len() - last..]
+    } else {
+        &snapshots
+    };
+
+    println!(
+        "{:<12} {:<22} {:>8} {:>10} {:>10} {:>8}",
+        "SNAPSHOT", "TIMESTAMP", "SCORE", "MODULES", "VIOLATIONS", "DELTA"
+    );
+    println!("{}", "-".repeat(76));
+
+    let mut prev_score: Option<f64> = None;
+
+    for snap in display_snapshots {
+        let modules = module_repo.get_by_snapshot(&snap.id)?;
+        let dependencies = dep_repo.get_by_snapshot(&snap.id)?;
+
+        let mut result = analyzer::audit(&modules, &dependencies);
+        result.filter_by_severity(project_settings.thresholds.minimum_severity);
+
+        let delta = match prev_score {
+            Some(prev) => {
+                let d = result.score - prev;
+                if d > 0.0 {
+                    format!("+{:.1}", d)
+                } else if d < 0.0 {
+                    format!("{:.1}", d)
+                } else {
+                    "0.0".to_string()
+                }
+            }
+            None => "-".to_string(),
+        };
+
+        let short_id = if snap.id.len() > 8 {
+            &snap.id[..8]
+        } else {
+            &snap.id
+        };
+
+        println!(
+            "{:<12} {:<22} {:>7.1} {:>10} {:>10} {:>8}",
+            short_id,
+            snap.timestamp,
+            result.score,
+            result.total_modules,
+            result.violations.len(),
+            delta,
+        );
+
+        prev_score = Some(result.score);
+    }
+
+    println!(
+        "\nShowing {} of {} snapshots",
+        display_snapshots.len(),
+        snapshots.len()
+    );
+
+    Ok(())
 }
 
 fn find_db(project_path: &str) -> anyhow::Result<storage::Database> {

--- a/src/storage/repository.rs
+++ b/src/storage/repository.rs
@@ -64,6 +64,20 @@ impl<'a> SnapshotRepository<'a> {
             None => Ok(None),
         }
     }
+
+    pub fn get_all(&self) -> Result<Vec<Snapshot>> {
+        let mut stmt = self
+            .conn
+            .prepare("SELECT id, timestamp, root_path FROM snapshots ORDER BY rowid")?;
+        let rows = stmt.query_map([], |row| {
+            Ok(Snapshot {
+                id: row.get(0)?,
+                timestamp: row.get(1)?,
+                root_path: row.get(2)?,
+            })
+        })?;
+        Ok(rows.filter_map(|r| r.ok()).collect())
+    }
 }
 
 /// Repository for bulk inserting and querying source modules.


### PR DESCRIPTION
## Summary

New command: `noupling trend .` shows health score history:

```
SNAPSHOT     TIMESTAMP                 SCORE    MODULES VIOLATIONS    DELTA
----------------------------------------------------------------------------
a30c0502     2026-04-14 08:41:00       83.6         40          7        -
1f89b1e0     2026-04-14 08:41:00       83.6         40          7      0.0
aef07b84     2026-04-14 08:41:01       83.6         40          7      0.0
```

- Score delta between consecutive snapshots
- `--last N` to limit history (default: 20)
- Uses existing SQLite snapshots, no schema changes

Closes #66

## Test plan
- [x] 152 tests passing
- [x] Zero clippy warnings
- [x] Trend output with multiple snapshots

Generated with [Claude Code](https://claude.ai/claude-code)