### PR TITLE
Suppress coupling violations that follow layer direction

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,35 @@ Settings are stored in `.noupling/settings.json` (auto-created on first run):
 | `ignore_patterns` | Glob patterns for dirs/files to skip | 15 defaults |
 | `source_extensions` | File types to scan | 14 extensions |
 
+### Architectural Layers
+
+Define layers to suppress coupling violations that follow the intended dependency direction:
+
+```json
+{
+  "layers": [
+    { "name": "presentation", "pattern": "**/ui/**" },
+    { "name": "domain", "pattern": "**/domain/**" },
+    { "name": "data", "pattern": "**/data/**" }
+  ]
+}
+```
+
+Dependencies may only flow **downward** (presentation -> domain -> data). Downward dependencies are not flagged as coupling violations. Upward dependencies (data -> presentation) are flagged as both coupling and layer violations.
+
+### Custom Dependency Rules
+
+Forbid specific dependency patterns:
+
+```json
+{
+  "dependency_rules": [
+    { "from": "**/ui/**", "to": "**/data/**", "allow": false,
+      "message": "UI must not depend on data layer directly" }
+  ]
+}
+```
+
 ---
 
 ## How It Works

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -126,6 +126,53 @@ impl AuditResult {
         self.recalculate_score();
     }
 
+    /// Remove coupling violations that follow the defined layer direction (downward).
+    /// Keeps circular violations and violations where modules have no layer assigned.
+    pub fn filter_by_layers(&mut self, layers: &[crate::settings::Layer]) {
+        if layers.is_empty() {
+            return;
+        }
+
+        // Build layer matchers and index
+        let layer_matchers: Vec<(usize, globset::GlobMatcher)> = layers
+            .iter()
+            .enumerate()
+            .filter_map(|(i, l)| {
+                globset::Glob::new(&l.pattern)
+                    .ok()
+                    .map(|g| (i, g.compile_matcher()))
+            })
+            .collect();
+
+        let get_layer = |path: &str| -> Option<usize> {
+            for (idx, matcher) in &layer_matchers {
+                if matcher.is_match(path) {
+                    return Some(*idx);
+                }
+            }
+            None
+        };
+
+        self.violations.retain(|v| {
+            // Always keep circular violations
+            if v.is_circular {
+                return true;
+            }
+
+            let from_layer = get_layer(&v.from_module);
+            let to_layer = get_layer(&v.to_module);
+
+            match (from_layer, to_layer) {
+                // Both have layers: suppress downward deps (from_idx < to_idx)
+                // Keep: same layer (from_idx == to_idx) or upward (from_idx > to_idx)
+                (Some(from_idx), Some(to_idx)) => from_idx >= to_idx,
+                // One or both unassigned: keep the violation
+                _ => true,
+            }
+        });
+        self.recalculate_score();
+    }
+
     /// Remove violations below the given severity threshold and recalculate the score.
     pub fn filter_by_severity(&mut self, minimum_severity: f64) {
         // Circular violations are always kept regardless of severity

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,6 +128,7 @@ fn run_trend(path: &str, last: usize) -> anyhow::Result<()> {
 
         let mut result = analyzer::audit(&modules, &dependencies);
         result.filter_by_severity(project_settings.thresholds.minimum_severity);
+        result.filter_by_layers(&project_settings.layers);
 
         let delta = match prev_score {
             Some(prev) => {
@@ -271,6 +272,7 @@ fn run_baseline(action: &str, path: &str) -> anyhow::Result<()> {
             let project_settings = settings::Settings::load(Path::new(path))?;
             let mut result = analyzer::audit(&modules, &dependencies);
             result.filter_by_severity(project_settings.thresholds.minimum_severity);
+            result.filter_by_layers(&project_settings.layers);
 
             baseline::save_baseline(Path::new(path), &result)?;
         }
@@ -308,6 +310,7 @@ fn run_audit(
     let project_settings = settings::Settings::load(Path::new(path))?;
     let mut result = analyzer::audit(&modules, &dependencies);
     result.filter_by_severity(project_settings.thresholds.minimum_severity);
+    result.filter_by_layers(&project_settings.layers);
     result.rule_violations = analyzer::check_dependency_rules(
         &modules,
         &dependencies,
@@ -370,6 +373,7 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
     let project_settings = settings::Settings::load(Path::new(path))?;
     let mut result = analyzer::audit(&modules, &dependencies);
     result.filter_by_severity(project_settings.thresholds.minimum_severity);
+    result.filter_by_layers(&project_settings.layers);
     result.rule_violations = analyzer::check_dependency_rules(
         &modules,
         &dependencies,


### PR DESCRIPTION
## Summary

When `layers` are defined in settings.json, downward dependencies are no longer flagged as coupling violations. Only upward and same-layer cross-directory deps are flagged.

**Before (no layers):** Score 83.6, 7 violations
**After (layers defined):** Score 97.8, 2 violations

This means teams can define their intended architecture and noupling only flags violations of that architecture, not the architecture itself.

```json
{
  "layers": [
    { "name": "reporter", "pattern": "**/reporter/**" },
    { "name": "analyzer", "pattern": "**/analyzer/**" },
    { "name": "core", "pattern": "**/core/**" }
  ]
}
```

`reporter -> analyzer -> core` = downward = suppressed
`core -> reporter` = upward = violation

Closes #110

## Test plan
- [x] 152 tests passing
- [x] Zero clippy warnings
- [x] Without layers: unchanged behavior
- [x] With layers: downward deps suppressed, score improves

Generated with [Claude Code](https://claude.ai/claude-code)