### PR TITLE
feat: inline suppression via noupling:ignore comments (#73)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -73,6 +73,8 @@ pub struct AuditResult {
     pub cohesion: Vec<CohesionMetrics>,
     /// Total excess: sum of all imports that need removal to fix all violations.
     pub total_xs: usize,
+    /// Number of imports suppressed by `noupling:ignore` comments.
+    pub suppressed_count: usize,
 }
 
 /// Cohesion metrics for a directory.
@@ -571,6 +573,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
     }
 
@@ -872,6 +875,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         layer_violations: Vec::new(),
         cohesion,
         total_xs,
+        suppressed_count: 0,
     }
 }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -151,6 +151,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         // Save baseline
@@ -167,6 +168,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
         assert_eq!(new, 0);
@@ -188,6 +190,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
 
@@ -204,6 +207,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 1);
@@ -226,6 +230,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
 
@@ -239,6 +244,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 0);

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,6 +83,15 @@ fn load_diff_meta(path: &str) -> Option<Vec<String>> {
     Some(files)
 }
 
+fn load_suppressed_count(path: &str) -> usize {
+    let meta_path = Path::new(path).join(".noupling").join("suppressed.json");
+    let content = std::fs::read_to_string(&meta_path).ok();
+    content
+        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
+        .and_then(|v| v["suppressed_count"].as_u64())
+        .unwrap_or(0) as usize
+}
+
 fn run_hook(action: &str, path: &str) -> anyhow::Result<()> {
     match action {
         "install" => hook::install(Path::new(path)),
@@ -212,8 +221,24 @@ fn run_scan(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
     println!("Created snapshot: {}", snapshot.id);
 
     // Always scan the full project (needed for dependency resolution)
-    let result = scanner::scan_project(project_path, &snapshot.id)?;
+    let scan_settings = settings::Settings::load(project_path)?;
+    let result = scanner::scan_project(
+        project_path,
+        &snapshot.id,
+        scan_settings.allow_inline_suppression,
+    )?;
     println!("Discovered {} modules", result.modules.len());
+    if result.suppressed_count > 0 {
+        println!(
+            "{} import{} suppressed by noupling:ignore comments",
+            result.suppressed_count,
+            if result.suppressed_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        );
+    }
 
     let module_repo = storage::repository::ModuleRepository::new(&db.conn);
     module_repo.bulk_insert(&result.modules)?;
@@ -235,6 +260,15 @@ fn run_scan(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
     let dep_repo = storage::repository::DependencyRepository::new(&db.conn);
     dep_repo.bulk_insert(&unique_deps)?;
     println!("Found {} dependencies", unique_deps.len());
+
+    // Store suppressed count for audit/report
+    let suppressed_path = project_path.join(".noupling").join("suppressed.json");
+    if result.suppressed_count > 0 {
+        let meta = serde_json::json!({ "suppressed_count": result.suppressed_count });
+        std::fs::write(&suppressed_path, serde_json::to_string(&meta)?)?;
+    } else {
+        let _ = std::fs::remove_file(&suppressed_path);
+    }
 
     // Store diff metadata alongside the snapshot
     if let Some(ref files) = changed_files {
@@ -319,6 +353,9 @@ fn run_audit(
     result.layer_violations =
         analyzer::check_layer_rules(&modules, &dependencies, &project_settings.layers);
 
+    // Load suppressed count from scan
+    result.suppressed_count = load_suppressed_count(path);
+
     // Apply diff filter if a diff scan was performed
     if let Some(changed_files) = load_diff_meta(path) {
         result.filter_by_changed_files(&changed_files);
@@ -381,6 +418,9 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
     );
     result.layer_violations =
         analyzer::check_layer_rules(&modules, &dependencies, &project_settings.layers);
+
+    // Load suppressed count from scan
+    result.suppressed_count = load_suppressed_count(path);
 
     // Apply diff filter if a diff scan was performed
     if let Some(changed_files) = load_diff_meta(path) {

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -254,6 +254,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let mermaid = format_mermaid(&modules, &result);
@@ -279,6 +280,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let dot = format_dot(&modules, &result);
@@ -301,6 +303,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let mermaid = format_mermaid(&modules, &result);

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -784,6 +784,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -805,6 +806,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -832,6 +834,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -875,6 +878,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let dir = tempfile::tempdir().unwrap();

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -24,6 +24,7 @@ pub struct JsonReport {
     pub score: f64,
     pub total_modules: usize,
     pub total_xs: usize,
+    pub suppressed_count: usize,
     pub critical_violations: usize,
     pub total_circular: usize,
     pub total_coupling: usize,
@@ -191,6 +192,7 @@ impl JsonReport {
             score: result.score,
             total_modules: result.total_modules,
             total_xs: result.total_xs,
+            suppressed_count: result.suppressed_count,
             critical_violations,
             total_circular: circular.len(),
             total_coupling: coupling.len(),
@@ -607,6 +609,17 @@ pub fn format_text(result: &AuditResult) -> String {
             if result.total_xs == 1 { "" } else { "s" }
         ));
     }
+    if result.suppressed_count > 0 {
+        output.push_str(&format!(
+            "Suppressed: {} import{} via noupling:ignore\n",
+            result.suppressed_count,
+            if result.suppressed_count == 1 {
+                ""
+            } else {
+                "s"
+            }
+        ));
+    }
 
     if !result.violations.is_empty() {
         output.push('\n');
@@ -861,6 +874,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-1");
@@ -887,6 +901,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-2");
@@ -910,6 +925,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-3");
@@ -927,6 +943,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let text = format_text(&result);
@@ -946,6 +963,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let text = format_text(&result);
@@ -965,6 +983,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-1");
@@ -992,6 +1011,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-3");
@@ -1011,6 +1031,7 @@ mod tests {
             layer_violations: Vec::new(),
             cohesion: Vec::new(),
             total_xs: 0,
+            suppressed_count: 0,
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-4");

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -22,15 +22,46 @@ pub struct ScanResult {
     pub modules: Vec<Module>,
     /// All resolved import dependencies between modules.
     pub dependencies: Vec<Dependency>,
+    /// Number of imports suppressed by `noupling:ignore` comments.
+    pub suppressed_count: usize,
 }
 
-pub fn scan_project(root: &Path, snapshot_id: &str) -> Result<ScanResult> {
+/// Check if an import line is suppressed by a `noupling:ignore` comment.
+/// Checks the import line itself for an inline comment, and the line above
+/// if it is a standalone comment line (starts with //, #, or --).
+fn is_suppressed(source: &str, line_number: i32) -> bool {
+    let lines: Vec<&str> = source.lines().collect();
+    let idx = (line_number - 1) as usize;
+
+    // Check the import line itself for an inline comment
+    if idx < lines.len() && lines[idx].contains("noupling:ignore") {
+        return true;
+    }
+
+    // Check the line above only if it's a standalone comment
+    if idx > 0 && (idx - 1) < lines.len() {
+        let above = lines[idx - 1].trim();
+        let is_comment =
+            above.starts_with("//") || above.starts_with('#') || above.starts_with("--");
+        if is_comment && above.contains("noupling:ignore") {
+            return true;
+        }
+    }
+
+    false
+}
+
+pub fn scan_project(
+    root: &Path,
+    snapshot_id: &str,
+    allow_inline_suppression: bool,
+) -> Result<ScanResult> {
     let root = root.canonicalize()?;
     let modules = discover_files(&root, snapshot_id)?;
 
     let all_paths: Vec<String> = modules.iter().map(|m| m.path.clone()).collect();
 
-    let dependencies: Vec<Dependency> = modules
+    let per_file: Vec<(Vec<Dependency>, usize)> = modules
         .par_iter()
         .filter_map(|module| {
             let rel_path = Path::new(&module.path);
@@ -52,9 +83,14 @@ pub fn scan_project(root: &Path, snapshot_id: &str) -> Result<ScanResult> {
                 "zig" => parser::parse_zig_imports(&source),
                 _ => return None,
             };
+            let mut suppressed = 0usize;
             let deps: Vec<Dependency> = imports
                 .iter()
                 .filter_map(|entry| {
+                    if allow_inline_suppression && is_suppressed(&source, entry.line_number) {
+                        suppressed += 1;
+                        return None;
+                    }
                     let resolved =
                         resolve_import(&entry.path, &module.path, Path::new(""), &all_paths)?;
                     let to_module = modules.iter().find(|m| m.path == resolved)?;
@@ -65,14 +101,21 @@ pub fn scan_project(root: &Path, snapshot_id: &str) -> Result<ScanResult> {
                     })
                 })
                 .collect();
-            Some(deps)
+            Some((deps, suppressed))
         })
-        .flatten()
         .collect();
+
+    let mut dependencies = Vec::new();
+    let mut suppressed_count = 0usize;
+    for (deps, suppressed) in per_file {
+        dependencies.extend(deps);
+        suppressed_count += suppressed;
+    }
 
     Ok(ScanResult {
         modules,
         dependencies,
+        suppressed_count,
     })
 }
 
@@ -85,7 +128,7 @@ mod tests {
     fn scan_project_discovers_modules_and_deps() {
         let fixture =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mock_rust_project");
-        let result = scan_project(&fixture, "test-snap").unwrap();
+        let result = scan_project(&fixture, "test-snap", true).unwrap();
 
         // Only source files, no directories
         assert!(result
@@ -112,10 +155,52 @@ mod tests {
         let fixture =
             Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/mock_rust_project");
 
-        let r1 = scan_project(&fixture, "snap-1").unwrap();
-        let r2 = scan_project(&fixture, "snap-2").unwrap();
+        let r1 = scan_project(&fixture, "snap-1", true).unwrap();
+        let r2 = scan_project(&fixture, "snap-2", true).unwrap();
 
         assert_eq!(r1.modules.len(), r2.modules.len());
         assert_eq!(r1.dependencies.len(), r2.dependencies.len());
+    }
+
+    #[test]
+    fn is_suppressed_same_line() {
+        let source = "use crate::foo; // noupling:ignore\nuse crate::bar;\n";
+        assert!(is_suppressed(source, 1));
+        assert!(!is_suppressed(source, 2));
+    }
+
+    #[test]
+    fn is_suppressed_line_above() {
+        let source = "// noupling:ignore\nuse crate::foo;\nuse crate::bar;\n";
+        assert!(is_suppressed(source, 2));
+        assert!(!is_suppressed(source, 3));
+    }
+
+    #[test]
+    fn is_suppressed_python_comment() {
+        let source = "# noupling:ignore\nimport foo\nimport bar\n";
+        assert!(is_suppressed(source, 2));
+        assert!(!is_suppressed(source, 3));
+    }
+
+    #[test]
+    fn is_suppressed_haskell_comment() {
+        let source = "-- noupling:ignore\nimport Data.List\nimport Data.Map\n";
+        assert!(is_suppressed(source, 2));
+        assert!(!is_suppressed(source, 3));
+    }
+
+    #[test]
+    fn is_suppressed_inline_same_line_kotlin() {
+        let source = "import com.example.foo // noupling:ignore\nimport com.example.bar\n";
+        assert!(is_suppressed(source, 1));
+        assert!(!is_suppressed(source, 2));
+    }
+
+    #[test]
+    fn is_suppressed_not_triggered_without_comment() {
+        let source = "use crate::foo;\nuse crate::bar;\n";
+        assert!(!is_suppressed(source, 1));
+        assert!(!is_suppressed(source, 2));
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -26,6 +26,13 @@ pub struct Settings {
     /// Architectural layers (ordered top to bottom). Dependencies may only flow downward.
     #[serde(default)]
     pub layers: Vec<Layer>,
+    /// Whether `noupling:ignore` inline comments are allowed. Default: true.
+    #[serde(default = "default_allow_inline_suppression")]
+    pub allow_inline_suppression: bool,
+}
+
+fn default_allow_inline_suppression() -> bool {
+    true
 }
 
 /// An architectural layer. Dependencies may only flow downward (higher index = lower layer).
@@ -146,6 +153,7 @@ impl Default for Settings {
             source_extensions: default_source_extensions(),
             dependency_rules: Vec::new(),
             layers: Vec::new(),
+            allow_inline_suppression: default_allow_inline_suppression(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `// noupling:ignore` comment support to suppress specific import violations
- Comment on the same line or the line above the import works
- Supports all comment styles: `//` (C-like), `#` (Python), `--` (Haskell)
- Add `allow_inline_suppression` setting in `settings.json` (default: `true`, set to `false` to enforce no suppressions)
- Suppressed count shown in scan output, audit text, and JSON report

## Usage

```kotlin
import com.example.data.Repository // noupling:ignore

// noupling:ignore
import com.example.data.Database
```

```python
# noupling:ignore
import data.repository
```

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo test` — 158 tests pass (6 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Test with real project containing `noupling:ignore` comments

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)