### PR TITLE
feat: monorepo support with per-module analysis (#84)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1005,6 +1005,141 @@ pub fn check_layer_rules(
     violations
 }
 
+/// A cross-module dependency that violates the declared `depends_on` graph.
+#[derive(Debug, Clone)]
+pub struct CrossModuleViolation {
+    /// Source module config name (e.g., "app").
+    pub from_config: String,
+    /// Target module config name (e.g., "lib-network").
+    pub to_config: String,
+    /// Source file path.
+    pub from_file: String,
+    /// Target file path.
+    pub to_file: String,
+    /// Line number of the import.
+    pub line_number: i32,
+}
+
+/// Result of analyzing a monorepo with multiple configured modules.
+#[derive(Debug)]
+pub struct MonorepoResult {
+    /// Per-module audit results: (module_name, audit_result).
+    pub module_results: Vec<(String, AuditResult)>,
+    /// Cross-module violations (imports not declared in depends_on).
+    pub cross_module_violations: Vec<CrossModuleViolation>,
+    /// Weighted average score across all modules.
+    pub overall_score: f64,
+    /// Total source files across all modules.
+    pub total_modules: usize,
+}
+
+/// Run independent audits per configured module and detect cross-module violations.
+pub fn audit_modules(
+    all_modules: &[Module],
+    all_dependencies: &[Dependency],
+    module_configs: &[crate::settings::ModuleConfig],
+) -> MonorepoResult {
+    let id_to_path: FxHashMap<&str, &str> = all_modules
+        .iter()
+        .map(|m| (m.id.as_str(), m.path.as_str()))
+        .collect();
+
+    // Map each file to which module config it belongs to (first match wins)
+    let mut file_to_config: FxHashMap<&str, usize> = FxHashMap::default();
+    for module in all_modules {
+        for (i, cfg) in module_configs.iter().enumerate() {
+            let prefix = format!("{}/", cfg.path);
+            if module.path.starts_with(&prefix) || module.path == cfg.path {
+                file_to_config.insert(module.id.as_str(), i);
+                break;
+            }
+        }
+    }
+
+    // Run independent audit per module
+    let mut module_results: Vec<(String, AuditResult)> = Vec::new();
+    let mut total_files = 0usize;
+    let mut weighted_score_sum = 0.0f64;
+
+    for (i, cfg) in module_configs.iter().enumerate() {
+        let module_ids: FxHashSet<&str> = file_to_config
+            .iter()
+            .filter(|(_, &config_idx)| config_idx == i)
+            .map(|(&id, _)| id)
+            .collect();
+
+        let filtered_modules: Vec<Module> = all_modules
+            .iter()
+            .filter(|m| module_ids.contains(m.id.as_str()))
+            .cloned()
+            .collect();
+
+        let filtered_deps: Vec<Dependency> = all_dependencies
+            .iter()
+            .filter(|d| {
+                module_ids.contains(d.from_module_id.as_str())
+                    && module_ids.contains(d.to_module_id.as_str())
+            })
+            .cloned()
+            .collect();
+
+        let result = audit(&filtered_modules, &filtered_deps);
+        let file_count = filtered_modules.len();
+        weighted_score_sum += result.score * file_count as f64;
+        total_files += file_count;
+        module_results.push((cfg.name.clone(), result));
+    }
+
+    // Detect cross-module violations
+    let mut cross_module_violations = Vec::new();
+    for dep in all_dependencies {
+        let from_cfg = file_to_config.get(dep.from_module_id.as_str()).copied();
+        let to_cfg = file_to_config.get(dep.to_module_id.as_str()).copied();
+
+        if let (Some(from_idx), Some(to_idx)) = (from_cfg, to_cfg) {
+            if from_idx != to_idx {
+                let from_config = &module_configs[from_idx];
+                let to_config = &module_configs[to_idx];
+                if !from_config.depends_on.contains(&to_config.name) {
+                    cross_module_violations.push(CrossModuleViolation {
+                        from_config: from_config.name.clone(),
+                        to_config: to_config.name.clone(),
+                        from_file: id_to_path
+                            .get(dep.from_module_id.as_str())
+                            .unwrap_or(&"")
+                            .to_string(),
+                        to_file: id_to_path
+                            .get(dep.to_module_id.as_str())
+                            .unwrap_or(&"")
+                            .to_string(),
+                        line_number: dep.line_number,
+                    });
+                }
+            }
+        }
+    }
+
+    // Apply cross-module penalty to overall score
+    let cross_penalty = if total_files > 0 {
+        cross_module_violations.len() as f64 / total_files as f64 * 100.0
+    } else {
+        0.0
+    };
+
+    let overall_score = if total_files > 0 {
+        (weighted_score_sum / total_files as f64 - cross_penalty).max(0.0)
+    } else {
+        100.0
+    };
+
+    MonorepoResult {
+        module_results,
+        cross_module_violations,
+        overall_score,
+        total_modules: total_files,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1310,5 +1445,142 @@ mod tests {
             !circular.is_empty(),
             "Should detect transitive circular dependency"
         );
+    }
+
+    #[test]
+    fn audit_modules_independent_analysis() {
+        let modules = vec![
+            make_module("a1", "app/src/main.rs"),
+            make_module("a2", "app/src/util.rs"),
+            make_module("l1", "lib/src/core.rs"),
+            make_module("l2", "lib/src/helper.rs"),
+        ];
+        // Coupling within app module only
+        let deps = vec![Dependency {
+            from_module_id: "a1".to_string(),
+            to_module_id: "a2".to_string(),
+            line_number: 1,
+        }];
+        let configs = vec![
+            crate::settings::ModuleConfig {
+                name: "app".to_string(),
+                path: "app/src".to_string(),
+                depends_on: vec![],
+            },
+            crate::settings::ModuleConfig {
+                name: "lib".to_string(),
+                path: "lib/src".to_string(),
+                depends_on: vec![],
+            },
+        ];
+
+        let result = audit_modules(&modules, &deps, &configs);
+        assert_eq!(result.module_results.len(), 2);
+        assert_eq!(result.module_results[0].0, "app");
+        assert_eq!(result.module_results[1].0, "lib");
+        // lib has no violations
+        assert_eq!(result.module_results[1].1.violations.len(), 0);
+        assert!(result.cross_module_violations.is_empty());
+    }
+
+    #[test]
+    fn audit_modules_cross_module_violation() {
+        let modules = vec![
+            make_module("a1", "app/src/main.rs"),
+            make_module("l1", "lib/src/core.rs"),
+        ];
+        // app imports lib without declaring depends_on
+        let deps = vec![Dependency {
+            from_module_id: "a1".to_string(),
+            to_module_id: "l1".to_string(),
+            line_number: 5,
+        }];
+        let configs = vec![
+            crate::settings::ModuleConfig {
+                name: "app".to_string(),
+                path: "app/src".to_string(),
+                depends_on: vec![], // does NOT list "lib"
+            },
+            crate::settings::ModuleConfig {
+                name: "lib".to_string(),
+                path: "lib/src".to_string(),
+                depends_on: vec![],
+            },
+        ];
+
+        let result = audit_modules(&modules, &deps, &configs);
+        assert_eq!(result.cross_module_violations.len(), 1);
+        assert_eq!(result.cross_module_violations[0].from_config, "app");
+        assert_eq!(result.cross_module_violations[0].to_config, "lib");
+    }
+
+    #[test]
+    fn audit_modules_allowed_cross_dep() {
+        let modules = vec![
+            make_module("a1", "app/src/main.rs"),
+            make_module("l1", "lib/src/core.rs"),
+        ];
+        let deps = vec![Dependency {
+            from_module_id: "a1".to_string(),
+            to_module_id: "l1".to_string(),
+            line_number: 5,
+        }];
+        let configs = vec![
+            crate::settings::ModuleConfig {
+                name: "app".to_string(),
+                path: "app/src".to_string(),
+                depends_on: vec!["lib".to_string()], // allowed
+            },
+            crate::settings::ModuleConfig {
+                name: "lib".to_string(),
+                path: "lib/src".to_string(),
+                depends_on: vec![],
+            },
+        ];
+
+        let result = audit_modules(&modules, &deps, &configs);
+        assert!(result.cross_module_violations.is_empty());
+    }
+
+    #[test]
+    fn audit_modules_weighted_score() {
+        let modules = vec![
+            make_module("a1", "app/src/main.rs"),
+            make_module("a2", "app/src/util.rs"),
+            make_module("a3", "app/src/helper.rs"),
+            make_module("l1", "lib/src/core.rs"),
+        ];
+        // No deps = perfect scores
+        let deps = vec![];
+        let configs = vec![
+            crate::settings::ModuleConfig {
+                name: "app".to_string(),
+                path: "app/src".to_string(),
+                depends_on: vec![],
+            },
+            crate::settings::ModuleConfig {
+                name: "lib".to_string(),
+                path: "lib/src".to_string(),
+                depends_on: vec![],
+            },
+        ];
+
+        let result = audit_modules(&modules, &deps, &configs);
+        // Both modules have score 100, weighted average is 100
+        assert!((result.overall_score - 100.0).abs() < 0.01);
+        assert_eq!(result.total_modules, 4);
+    }
+
+    #[test]
+    fn audit_modules_empty_config_not_used() {
+        // This test verifies the fallback path works by ensuring
+        // audit_modules with empty config returns empty results
+        let modules = vec![make_module("a1", "src/main.rs")];
+        let deps = vec![];
+        let configs = vec![];
+
+        let result = audit_modules(&modules, &deps, &configs);
+        assert!(result.module_results.is_empty());
+        assert_eq!(result.overall_score, 100.0);
     }
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -132,6 +132,11 @@ pub enum Commands {
         /// not in .noupling/baseline.json. Exit code 1 only on new violations.
         #[arg(long)]
         baseline: bool,
+
+        /// Show results for a specific module only (monorepo mode).
+        /// Module names are defined in .noupling/settings.json under "modules".
+        #[arg(long, value_name = "NAME")]
+        module: Option<String>,
     },
 
     /// Show health score history across snapshots. Track architectural drift over time.
@@ -161,6 +166,11 @@ pub enum Commands {
         /// sonar - SonarCloud/SonarQube generic issue import format (sonar.externalIssuesReportPaths).
         #[arg(long)]
         format: String,
+
+        /// Generate report for a specific module only (monorepo mode).
+        /// Module names are defined in .noupling/settings.json under "modules".
+        #[arg(long, value_name = "NAME")]
+        module: Option<String>,
     },
 }
 
@@ -190,6 +200,7 @@ mod tests {
                 path,
                 fail_below,
                 baseline,
+                ..
             } => {
                 assert!(snapshot.is_none());
                 assert_eq!(path, ".");
@@ -231,7 +242,7 @@ mod tests {
     fn parse_report_json() {
         let cli = Cli::parse_from(["noupling", "report", "--format", "json"]);
         match cli.command {
-            Commands::Report { format, path } => {
+            Commands::Report { format, path, .. } => {
                 assert_eq!(format, "json");
                 assert_eq!(path, ".");
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,9 +43,20 @@ fn main() {
             snapshot,
             fail_below,
             baseline,
-        } => run_audit(&path, snapshot.as_deref(), fail_below, baseline),
+            module,
+        } => run_audit(
+            &path,
+            snapshot.as_deref(),
+            fail_below,
+            baseline,
+            module.as_deref(),
+        ),
         Commands::Trend { path, last } => run_trend(&path, last),
-        Commands::Report { path, format } => run_report(&path, &format),
+        Commands::Report {
+            path,
+            format,
+            module,
+        } => run_report(&path, &format, module.as_deref()),
     };
 
     if let Err(e) = result {
@@ -322,6 +333,7 @@ fn run_audit(
     snapshot_id: Option<&str>,
     fail_below: Option<f64>,
     use_baseline: bool,
+    module_filter: Option<&str>,
 ) -> anyhow::Result<()> {
     let db = find_db(path)?;
     let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
@@ -342,6 +354,57 @@ fn run_audit(
     let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
 
     let project_settings = settings::Settings::load(Path::new(path))?;
+
+    // Monorepo mode: multiple configured modules
+    if !project_settings.modules.is_empty() {
+        let monorepo = analyzer::audit_modules(&modules, &dependencies, &project_settings.modules);
+
+        if let Some(name) = module_filter {
+            // Single module output
+            let (_, result) = monorepo
+                .module_results
+                .iter()
+                .find(|(n, _)| n == name)
+                .ok_or_else(|| {
+                    anyhow::anyhow!(
+                        "Module '{}' not found. Available: {}",
+                        name,
+                        monorepo
+                            .module_results
+                            .iter()
+                            .map(|(n, _)| n.as_str())
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    )
+                })?;
+            print!("{}", reporter::format_text(result));
+            if let Some(threshold) = fail_below {
+                if result.score < threshold {
+                    anyhow::bail!(
+                        "Module '{}' score {:.1} is below threshold {:.1}",
+                        name,
+                        result.score,
+                        threshold
+                    );
+                }
+            }
+        } else {
+            // Multi-module summary
+            print!("{}", reporter::format_monorepo_text(&monorepo));
+            if let Some(threshold) = fail_below {
+                if monorepo.overall_score < threshold {
+                    anyhow::bail!(
+                        "Overall score {:.1} is below threshold {:.1}",
+                        monorepo.overall_score,
+                        threshold
+                    );
+                }
+            }
+        }
+        return Ok(());
+    }
+
+    // Single-project mode (existing behavior)
     let mut result = analyzer::audit(&modules, &dependencies);
     result.filter_by_severity(project_settings.thresholds.minimum_severity);
     result.filter_by_layers(&project_settings.layers);
@@ -393,7 +456,7 @@ fn run_audit(
     Ok(())
 }
 
-fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
+fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::Result<()> {
     let db = find_db(path)?;
     let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
 
@@ -408,16 +471,45 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
     let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
 
     let project_settings = settings::Settings::load(Path::new(path))?;
-    let mut result = analyzer::audit(&modules, &dependencies);
+
+    // If --module specified with monorepo config, filter to that module's files
+    let (report_modules, report_deps) = if let Some(name) = module_filter {
+        let cfg = project_settings
+            .modules
+            .iter()
+            .find(|m| m.name == name)
+            .ok_or_else(|| anyhow::anyhow!("Module '{}' not found in settings", name))?;
+        let prefix = format!("{}/", cfg.path);
+        let filtered_modules: Vec<_> = modules
+            .iter()
+            .filter(|m| m.path.starts_with(&prefix) || m.path == cfg.path)
+            .cloned()
+            .collect();
+        let module_ids: std::collections::HashSet<&str> =
+            filtered_modules.iter().map(|m| m.id.as_str()).collect();
+        let filtered_deps: Vec<_> = dependencies
+            .iter()
+            .filter(|d| {
+                module_ids.contains(d.from_module_id.as_str())
+                    && module_ids.contains(d.to_module_id.as_str())
+            })
+            .cloned()
+            .collect();
+        (filtered_modules, filtered_deps)
+    } else {
+        (modules, dependencies)
+    };
+
+    let mut result = analyzer::audit(&report_modules, &report_deps);
     result.filter_by_severity(project_settings.thresholds.minimum_severity);
     result.filter_by_layers(&project_settings.layers);
     result.rule_violations = analyzer::check_dependency_rules(
-        &modules,
-        &dependencies,
+        &report_modules,
+        &report_deps,
         &project_settings.dependency_rules,
     );
     result.layer_violations =
-        analyzer::check_layer_rules(&modules, &dependencies, &project_settings.layers);
+        analyzer::check_layer_rules(&report_modules, &report_deps, &project_settings.layers);
 
     // Load suppressed count from scan
     result.suppressed_count = load_suppressed_count(path);
@@ -432,7 +524,7 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
 
     match format {
         "json" => {
-            let report = reporter::JsonReport::from_audit(&modules, &result, &snapshot.id);
+            let report = reporter::JsonReport::from_audit(&report_modules, &result, &snapshot.id);
             let content = report.to_json()?;
             let file_path = report_dir.join("report.json");
             std::fs::write(&file_path, &content)?;
@@ -440,11 +532,11 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
         }
         "md" => {
             let md_dir = report_dir.join("report-md");
-            reporter::generate_markdown_report(&modules, &result, &snapshot.id, &md_dir)?;
+            reporter::generate_markdown_report(&report_modules, &result, &snapshot.id, &md_dir)?;
             println!("Report saved to {}/README.md", md_dir.display());
         }
         "xml" => {
-            let content = reporter::format_xml(&modules, &result, &snapshot.id);
+            let content = reporter::format_xml(&report_modules, &result, &snapshot.id);
             let file_path = report_dir.join("report.xml");
             std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());
@@ -462,7 +554,7 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
         "html" => {
             let html_dir = report_dir.join("report");
             reporter::generate_html_report(
-                &modules,
+                &report_modules,
                 &result,
                 &snapshot.id,
                 &html_dir,
@@ -471,13 +563,13 @@ fn run_report(path: &str, format: &str) -> anyhow::Result<()> {
             println!("Report saved to {}/index.html", html_dir.display());
         }
         "mermaid" => {
-            let content = reporter::format_mermaid(&modules, &result);
+            let content = reporter::format_mermaid(&report_modules, &result);
             let file_path = report_dir.join("report.mermaid");
             std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());
         }
         "dot" => {
-            let content = reporter::format_dot(&modules, &result);
+            let content = reporter::format_dot(&report_modules, &result);
             let file_path = report_dir.join("report.dot");
             std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -709,6 +709,51 @@ pub fn format_text(result: &AuditResult) -> String {
     output
 }
 
+pub fn format_monorepo_text(monorepo: &crate::analyzer::MonorepoResult) -> String {
+    let mut output = String::new();
+
+    output.push_str(&format!(
+        "Overall Score: {:.1}/100\n",
+        monorepo.overall_score
+    ));
+    output.push_str(&format!("Total Modules: {}\n\n", monorepo.total_modules));
+    output.push_str(&format!(
+        "{:<20} {:>8} {:>10} {:>12}\n",
+        "MODULE", "SCORE", "MODULES", "VIOLATIONS"
+    ));
+    output.push_str(&format!("{}\n", "-".repeat(52)));
+
+    for (name, result) in &monorepo.module_results {
+        output.push_str(&format!(
+            "{:<20} {:>7.1} {:>10} {:>12}\n",
+            name,
+            result.score,
+            result.total_modules,
+            result.violations.len(),
+        ));
+    }
+
+    if !monorepo.cross_module_violations.is_empty() {
+        output.push_str(&format!(
+            "\nCross-Module Violations ({}):\n",
+            monorepo.cross_module_violations.len()
+        ));
+        for v in &monorepo.cross_module_violations {
+            output.push_str(&format!(
+                "  {} -> {} (not in depends_on)\n",
+                v.from_config, v.to_config
+            ));
+            output.push_str(&format!(
+                "    {} -> {} (line {})\n",
+                v.from_file, v.to_file, v.line_number
+            ));
+        }
+    }
+
+    output.push_str(&format!("\n{}\n", VERSION));
+    output
+}
+
 // Single-file markdown kept for backward compat in tests
 fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id: &str) -> String {
     let report = JsonReport::from_audit(modules, result, snapshot_id);

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -29,10 +29,25 @@ pub struct Settings {
     /// Whether `noupling:ignore` inline comments are allowed. Default: true.
     #[serde(default = "default_allow_inline_suppression")]
     pub allow_inline_suppression: bool,
+    /// Monorepo modules. Each gets independent analysis. If empty, whole project is one module.
+    #[serde(default)]
+    pub modules: Vec<ModuleConfig>,
 }
 
 fn default_allow_inline_suppression() -> bool {
     true
+}
+
+/// A module within a monorepo. Each module is analyzed independently.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ModuleConfig {
+    /// Human-readable name (e.g., "app", "lib-core").
+    pub name: String,
+    /// Relative path from project root (e.g., "app/src").
+    pub path: String,
+    /// Module names this module may import from. Unlisted cross-module imports are violations.
+    #[serde(default)]
+    pub depends_on: Vec<String>,
 }
 
 /// An architectural layer. Dependencies may only flow downward (higher index = lower layer).
@@ -154,6 +169,7 @@ impl Default for Settings {
             dependency_rules: Vec::new(),
             layers: Vec::new(),
             allow_inline_suppression: default_allow_inline_suppression(),
+            modules: Vec::new(),
         }
     }
 }


### PR DESCRIPTION
## Summary

- Add `modules` config in `settings.json` with `name`, `path`, and `depends_on` fields
- Each module gets independent analysis (own D_acc, BFS, cycle detection, health score)
- Cross-module dependencies validated against declared `depends_on` graph
- `--module <name>` flag on `audit` and `report` commands to filter to a single module
- Overall score is weighted average by file count, with cross-module penalty
- Fully backward compatible — no config means existing single-module behavior

## Usage

```json
// .noupling/settings.json
{
  "modules": [
    { "name": "app", "path": "app/src", "depends_on": ["lib-core"] },
    { "name": "lib-core", "path": "lib/core/src", "depends_on": [] }
  ]
}
```

```bash
noupling scan .
noupling audit .                  # multi-module summary
noupling audit . --module app     # single module detail
noupling report . --format html --module lib-core
```

## Test plan

- [x] `RUSTFLAGS="-Dwarnings" cargo test` — 163 tests pass (5 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Test with real monorepo project

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)