### PR TITLE
release: v0.4.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noupling"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Per-Erik Bergman"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Every violation gets a **severity score** based on depth: problems at the root o
 - **14 languages**: C#, Dart, Go, Haskell, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Swift, TypeScript, Zig
 - **Tree-sitter parsing**: Fast, accurate AST-based import extraction (no regex)
 - **Parallel scanning**: Rayon-powered file discovery and parsing
-- **7 report formats**: JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT
+- **8 report formats**: JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Sunburst
 - **Interactive HTML report**: Kover-style drill-down with color-coded scores
+- **Sunburst visualization**: Zoomable D3.js dependency graph with animated drill-down
 - **Monorepo support**: Independent analysis per module with cross-module dependency validation
 - **Architectural layers**: Define dependency direction, suppress legitimate downward coupling
 - **XS metric**: Quantify refactoring cost per violation, find the weakest link in cycles
@@ -119,6 +120,7 @@ noupling report /path/to/project --format html    # Interactive HTML with drill-
 noupling report /path/to/project --format sonar   # SonarCloud generic issue import
 noupling report /path/to/project --format mermaid # Mermaid flowchart diagram
 noupling report /path/to/project --format dot     # GraphViz DOT graph
+noupling report /path/to/project --format bundle  # Zoomable sunburst with dependency edges
 ```
 
 ### Diff mode (PR/CI gate)

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -17,7 +17,7 @@
       <li><a href="docs.html">Docs</a></li>
       <li><a href="changelog.html" class="active">Changelog</a></li>
       <li><a href="https://github.com/pererikbergman/noupling">GitHub</a></li>
-      <li><span class="badge">v0.4.0</span></li>
+      <li><span class="badge">v0.4.1</span></li>
     </ul>
   </div>
 </nav>
@@ -29,6 +29,17 @@
     <p class="lead">
       Not a commit log. A narrative of architectural decisions&mdash;what broke, what was built, and why each change exists.
     </p>
+
+    <!-- ── v0.4.1 ─────────────────────────────────────── -->
+    <article class="release">
+      <h2>v0.4.1 &mdash; The Visualization Release</h2>
+      <div class="date">April 2026</div>
+
+      <h3><span class="tag tag-feat">feat</span> Sunburst dependency visualization (<a href="https://github.com/pererikbergman/noupling/issues/123">#123</a>)</h3>
+      <p><strong>The friction:</strong> Existing reports showed violations as lists and tables. Teams couldn't see the overall shape of their architecture&mdash;where coupling clusters lived, how dependencies flowed between layers, or which areas were cleanly separated.</p>
+      <p><strong>The implementation:</strong> A zoomable D3.js sunburst where concentric rings represent the directory hierarchy, color-coded by health score. Curved dependency edges connect inner ring segments, aggregated from all children underneath (using D_acc). Click any segment to zoom in with a smooth 750ms animated transition. Click the center to zoom back out. Edge hover tooltips show the exact from/to connection and import count.</p>
+      <p><strong>The ripple effect:</strong> Architecture becomes visible at a glance. Dense edge bundles between two areas immediately reveal coupling hotspots. The drill-down lets teams explore from the 10,000-foot view down to individual directory pairs.</p>
+    </article>
 
     <!-- ── v0.4.0 ─────────────────────────────────────── -->
     <article class="release">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -17,7 +17,7 @@
       <li><a href="docs.html" class="active">Docs</a></li>
       <li><a href="changelog.html">Changelog</a></li>
       <li><a href="https://github.com/pererikbergman/noupling">GitHub</a></li>
-      <li><span class="badge">v0.4.0</span></li>
+      <li><span class="badge">v0.4.1</span></li>
     </ul>
   </div>
 </nav>
@@ -140,7 +140,7 @@ noupling audit . --fail-below 80</code></pre>
       <h2 id="cmd-report">report</h2>
       <p>Generate a report file from the latest snapshot.</p>
 <pre><code class="language-bash">noupling report [PATH] --format &lt;FORMAT&gt; [--module NAME]</code></pre>
-      <p>Formats: <code>json</code>, <code>xml</code>, <code>md</code>, <code>html</code>, <code>sonar</code>, <code>mermaid</code>, <code>dot</code>. See <a href="#report-formats">Report Formats</a>.</p>
+      <p>Formats: <code>json</code>, <code>xml</code>, <code>md</code>, <code>html</code>, <code>sonar</code>, <code>mermaid</code>, <code>dot</code>, <code>bundle</code>. See <a href="#report-formats">Report Formats</a>.</p>
 
 
       <h2 id="cmd-trend">trend</h2>
@@ -303,6 +303,7 @@ noupling audit .</code></pre>
           <tr><td><code>sonar</code></td><td><code>.noupling/noupling-sonar.json</code></td><td>SonarCloud/SonarQube integration</td></tr>
           <tr><td><code>mermaid</code></td><td><code>.noupling/report.mermaid</code></td><td>Embed in Markdown, quick overview</td></tr>
           <tr><td><code>dot</code></td><td><code>.noupling/report.dot</code></td><td>GraphViz rendering, custom pipelines</td></tr>
+          <tr><td><code>bundle</code></td><td><code>.noupling/bundle.html</code></td><td>Zoomable sunburst with dependency edges</td></tr>
         </tbody>
       </table>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
       <li><a href="docs.html">Docs</a></li>
       <li><a href="changelog.html">Changelog</a></li>
       <li><a href="https://github.com/pererikbergman/noupling">GitHub</a></li>
-      <li><span class="badge">v0.4.0</span></li>
+      <li><span class="badge">v0.4.1</span></li>
     </ul>
   </div>
 </nav>
@@ -82,8 +82,8 @@
         </article>
         <article class="feature-card">
           <span class="icon">&#128230;</span>
-          <h3>7 report formats</h3>
-          <p>JSON, XML, Markdown, interactive HTML, SonarCloud, Mermaid, and GraphViz DOT. Integrate with any CI system or documentation pipeline.</p>
+          <h3>8 report formats</h3>
+          <p>JSON, XML, Markdown, interactive HTML, SonarCloud, Mermaid, GraphViz DOT, and zoomable Sunburst. Integrate with any CI system or documentation pipeline.</p>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## v0.4.1 Release

### New
- **Sunburst dependency visualization** (#123) — zoomable D3.js sunburst with animated drill-down, aggregated dependency edges between inner ring segments, health score color-coding, edge hover tooltips, tension slider, violations-only toggle. Usage: `noupling report . --format bundle`

### Updated
- README: 8 report formats, sunburst feature listed
- HTML docs site: version badges, bundle format in report table and CLI reference
- Changelog: narrative entry for sunburst visualization

### Stats
- **8 report formats** (up from 7)
- **172 tests** passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)