### PR TITLE
feat: interactive technical leader dashboard (#132)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -717,9 +717,14 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
             reporter::generate_bundle_report(&report_modules, &report_deps, &result, &file_path)?;
             println!("Report saved to {}", file_path.display());
         }
+        "dashboard" => {
+            let file_path = report_dir.join("dashboard.html");
+            reporter::generate_dashboard(&report_modules, &report_deps, &result, &file_path)?;
+            println!("Report saved to {}", file_path.display());
+        }
         _ => {
             anyhow::bail!(
-                "Unknown format: {}. Use 'json', 'xml', 'md', 'html', 'sonar', 'mermaid', 'dot', or 'bundle'.",
+                "Unknown format: {}. Use 'json', 'xml', 'md', 'html', 'sonar', 'mermaid', 'dot', 'bundle', or 'dashboard'.",
                 format
             );
         }

--- a/src/reporter/dashboard.rs
+++ b/src/reporter/dashboard.rs
@@ -1,0 +1,553 @@
+//! Interactive Technical Leader Dashboard.
+
+use crate::analyzer::AuditResult;
+use crate::core::{Dependency, Module};
+use serde::Serialize;
+use std::collections::{BTreeMap, HashMap};
+
+#[derive(Serialize)]
+pub struct DashboardData {
+    pub score: f64,
+    pub total_modules: usize,
+    pub total_violations: usize,
+    pub total_xs: usize,
+    pub max_depth: usize,
+    pub critical_path: Vec<String>,
+    pub violation_age: ViolationAge,
+    pub lowest_independence: Option<IndependenceEntry>,
+    pub highest_blast: Option<BlastEntry>,
+    pub modules_table: Vec<ModuleRow>,
+    pub risk_matrix: Vec<RiskDot>,
+    pub violation_types: ViolationTypes,
+    pub quick_wins: Vec<QuickWin>,
+    pub sunburst_tree: serde_json::Value,
+    pub sunburst_deps: Vec<DepEdge>,
+    pub sunburst_violation_deps: Vec<DepEdge>,
+}
+
+#[derive(Serialize)]
+pub struct ViolationAge {
+    pub new_count: usize,
+    pub recent_count: usize,
+    pub chronic_count: usize,
+}
+
+#[derive(Serialize)]
+pub struct IndependenceEntry {
+    pub name: String,
+    pub score: f64,
+}
+
+#[derive(Serialize)]
+pub struct BlastEntry {
+    pub name: String,
+    pub blast_radius: usize,
+}
+
+#[derive(Serialize)]
+pub struct ModuleRow {
+    pub name: String,
+    pub score: f64,
+    pub file_count: usize,
+    pub violations: usize,
+    pub circular: usize,
+    pub xs: usize,
+    pub independence: f64,
+    pub instability: f64,
+}
+
+#[derive(Serialize)]
+pub struct RiskDot {
+    pub name: String,
+    pub instability: f64,
+    pub blast_radius: usize,
+    pub file_count: usize,
+    pub score: f64,
+}
+
+#[derive(Serialize)]
+pub struct ViolationTypes {
+    pub coupling: usize,
+    pub circular: usize,
+}
+
+#[derive(Serialize)]
+pub struct QuickWin {
+    pub from: String,
+    pub to: String,
+    pub cost: usize,
+    pub is_circular: bool,
+}
+
+#[derive(Serialize)]
+pub struct DepEdge {
+    pub from: String,
+    pub to: String,
+}
+
+pub fn generate_dashboard(
+    modules: &[Module],
+    dependencies: &[Dependency],
+    result: &AuditResult,
+    output_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let data = build_dashboard_data(modules, dependencies, result);
+    let json = serde_json::to_string(&data)?;
+
+    let html = format!(
+        include_str!("dashboard_template.html"),
+        json = json,
+        version = super::VERSION,
+    );
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(output_path, html)?;
+    Ok(())
+}
+
+fn common_parent(a: &str, b: &str) -> String {
+    let a_parts: Vec<&str> = a.split('/').collect();
+    let b_parts: Vec<&str> = b.split('/').collect();
+    let mut len = 0;
+    for (x, y) in a_parts.iter().zip(b_parts.iter()) {
+        if x == y {
+            len += 1;
+        } else {
+            break;
+        }
+    }
+    if len > 0 {
+        a_parts[..len].join("/")
+    } else {
+        String::new()
+    }
+}
+
+fn build_dashboard_data(
+    modules: &[Module],
+    dependencies: &[Dependency],
+    result: &AuditResult,
+) -> DashboardData {
+    let id_to_path: HashMap<&str, &str> = modules
+        .iter()
+        .map(|m| (m.id.as_str(), m.path.as_str()))
+        .collect();
+
+    // Assign each violation to its common parent directory (matching HTML report)
+    let violation_parents: Vec<String> = result
+        .violations
+        .iter()
+        .map(|v| common_parent(&v.dir_a, &v.dir_b))
+        .collect();
+
+    // Find common prefix to get meaningful top-level directories (matching HTML report)
+    let all_paths: Vec<&str> = modules.iter().map(|m| m.path.as_str()).collect();
+    let common_root = find_full_common_prefix(&all_paths);
+
+    // Module scorecard: per first directory level after common prefix
+    let mut dir_files: BTreeMap<String, Vec<&str>> = BTreeMap::new();
+    for m in modules {
+        let rel = strip_prefix(&m.path, &common_root);
+        if let Some(top) = rel.split('/').next() {
+            if rel.contains('/') {
+                dir_files
+                    .entry(top.to_string())
+                    .or_default()
+                    .push(m.id.as_str());
+            }
+        }
+    }
+
+    // Also strip common prefix from violation parents
+    let violation_parents: Vec<String> = violation_parents
+        .iter()
+        .map(|p| strip_prefix(p, &common_root))
+        .collect();
+
+    let mut modules_table: Vec<ModuleRow> = Vec::new();
+    for (dir, file_ids) in &dir_files {
+        // Count violations whose common parent is within this directory
+        let prefix = format!("{}/", dir);
+        let violations = violation_parents
+            .iter()
+            .zip(result.violations.iter())
+            .filter(|(p, _)| *p == dir || p.starts_with(&prefix))
+            .count();
+        let circular = violation_parents
+            .iter()
+            .zip(result.violations.iter())
+            .filter(|(p, v)| v.is_circular && (*p == dir || p.starts_with(&prefix)))
+            .count();
+
+        let dir_sev: f64 = violation_parents
+            .iter()
+            .zip(result.violations.iter())
+            .filter(|(p, _)| *p == dir || p.starts_with(&prefix))
+            .map(|(_, v)| v.severity)
+            .sum();
+        let score = (100.0 * (1.0 - dir_sev / file_ids.len().max(1) as f64)).max(0.0);
+
+        let xs: usize = violation_parents
+            .iter()
+            .zip(result.violations.iter())
+            .filter(|(p, _)| *p == dir || p.starts_with(&prefix))
+            .map(|(_, v)| {
+                if v.is_circular {
+                    v.break_cost
+                } else {
+                    v.weight
+                }
+            })
+            .sum();
+
+        let independence = result
+            .independence
+            .iter()
+            .find(|i| i.dir == *dir)
+            .map(|i| i.independence)
+            .unwrap_or(1.0);
+
+        // Average instability for modules in this dir
+        let instabilities: Vec<f64> = result
+            .hotspots
+            .iter()
+            .filter(|h| h.path.starts_with(dir.as_str()))
+            .map(|h| h.instability)
+            .collect();
+        let avg_instability = if instabilities.is_empty() {
+            0.5
+        } else {
+            instabilities.iter().sum::<f64>() / instabilities.len() as f64
+        };
+
+        modules_table.push(ModuleRow {
+            name: dir.clone(),
+            score,
+            file_count: file_ids.len(),
+            violations,
+            circular,
+            xs,
+            independence,
+            instability: avg_instability,
+        });
+    }
+    modules_table.sort_by(|a, b| a.score.partial_cmp(&b.score).unwrap());
+
+    // Risk matrix: one dot per top-level directory
+    let risk_matrix: Vec<RiskDot> = modules_table
+        .iter()
+        .map(|m| {
+            let max_blast = result
+                .hotspots
+                .iter()
+                .filter(|h| h.path.starts_with(&m.name))
+                .map(|h| h.blast_radius)
+                .max()
+                .unwrap_or(0);
+            RiskDot {
+                name: m.name.clone(),
+                instability: m.instability,
+                blast_radius: max_blast,
+                file_count: m.file_count,
+                score: m.score,
+            }
+        })
+        .collect();
+
+    // Quick wins: violations with lowest cost
+    let mut quick_wins: Vec<QuickWin> = result
+        .violations
+        .iter()
+        .map(|v| {
+            let cost = if v.is_circular {
+                v.break_cost
+            } else {
+                v.weight
+            };
+            QuickWin {
+                from: short_name(&v.from_module),
+                to: short_name(&v.to_module),
+                cost,
+                is_circular: v.is_circular,
+            }
+        })
+        .collect();
+    quick_wins.sort_by_key(|w| w.cost);
+    quick_wins.truncate(5);
+
+    // Lowest independence
+    let lowest_independence = result.independence.first().map(|i| IndependenceEntry {
+        name: i.dir.clone(),
+        score: i.independence,
+    });
+
+    // Highest blast radius
+    let highest_blast = result
+        .hotspots
+        .iter()
+        .max_by_key(|h| h.blast_radius)
+        .map(|h| BlastEntry {
+            name: short_name(&h.path),
+            blast_radius: h.blast_radius,
+        });
+
+    // Violation types
+    let coupling = result.violations.iter().filter(|v| !v.is_circular).count();
+    let circular_count = result.violations.iter().filter(|v| v.is_circular).count();
+
+    // Sunburst data (reuse bundle logic)
+    let sunburst_tree = build_sunburst_tree(modules, result);
+    let sunburst_deps = build_sunburst_deps(modules, dependencies, &id_to_path);
+
+    // Violation-specific edges for the sunburst
+    let paths_list: Vec<&str> = modules.iter().map(|m| m.path.as_str()).collect();
+    let common_prefix = find_common_prefix(&paths_list);
+    let mut sunburst_violation_deps = Vec::new();
+    let mut v_seen = std::collections::HashSet::new();
+    for v in &result.violations {
+        if !v.is_circular {
+            let f = strip_prefix(&v.from_module, &common_prefix);
+            let t = strip_prefix(&v.to_module, &common_prefix);
+            if v_seen.insert((f.clone(), t.clone())) {
+                sunburst_violation_deps.push(DepEdge { from: f, to: t });
+            }
+        } else {
+            for (from_file, to_file, _) in &v.cycle_hop_files {
+                if !from_file.is_empty() && !to_file.is_empty() {
+                    let f = strip_prefix(from_file, &common_prefix);
+                    let t = strip_prefix(to_file, &common_prefix);
+                    if v_seen.insert((f.clone(), t.clone())) {
+                        sunburst_violation_deps.push(DepEdge { from: f, to: t });
+                    }
+                }
+            }
+        }
+    }
+
+    // Compute overall score as weighted average of module scores (matching HTML report)
+    let total_files: usize = modules_table.iter().map(|m| m.file_count).sum();
+    let weighted_score: f64 = modules_table
+        .iter()
+        .map(|m| m.score * m.file_count as f64)
+        .sum::<f64>();
+    let dashboard_score = if total_files > 0 {
+        weighted_score / total_files as f64
+    } else {
+        result.score
+    };
+    let dashboard_violations: usize = modules_table.iter().map(|m| m.violations).sum();
+    let dashboard_xs: usize = modules_table.iter().map(|m| m.xs).sum();
+
+    DashboardData {
+        score: dashboard_score,
+        total_modules: result.total_modules,
+        total_violations: dashboard_violations,
+        total_xs: dashboard_xs,
+        max_depth: result.max_depth,
+        critical_path: result.critical_path.iter().map(|p| short_name(p)).collect(),
+        violation_age: ViolationAge {
+            new_count: result.violation_age.new_count,
+            recent_count: result.violation_age.recent_count,
+            chronic_count: result.violation_age.chronic_count,
+        },
+        lowest_independence,
+        highest_blast,
+        modules_table,
+        risk_matrix,
+        violation_types: ViolationTypes {
+            coupling,
+            circular: circular_count,
+        },
+        quick_wins,
+        sunburst_tree,
+        sunburst_deps,
+        sunburst_violation_deps,
+    }
+}
+
+fn short_name(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn build_sunburst_tree(modules: &[Module], result: &AuditResult) -> serde_json::Value {
+    #[derive(Serialize)]
+    struct Node {
+        name: String,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        value: Option<usize>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        score: Option<f64>,
+        #[serde(skip_serializing_if = "Vec::is_empty")]
+        children: Vec<Node>,
+    }
+
+    let paths: Vec<&str> = modules.iter().map(|m| m.path.as_str()).collect();
+    let common = find_common_prefix(&paths);
+
+    // Compute per-directory severity and file count
+    let mut dir_severity: HashMap<String, f64> = HashMap::new();
+    let mut dir_files: HashMap<String, usize> = HashMap::new();
+    for m in modules {
+        let rel = strip_prefix(&m.path, &common);
+        // Accumulate to every ancestor directory
+        let parts: Vec<&str> = rel.split('/').collect();
+        for end in 1..parts.len() {
+            let dir = parts[..end].join("/");
+            *dir_files.entry(dir).or_insert(0) += 1;
+        }
+    }
+    for v in &result.violations {
+        // Assign violation to common parent of dir_a and dir_b (matching HTML report)
+        let a = strip_prefix(&v.dir_a, &common);
+        let b = strip_prefix(&v.dir_b, &common);
+        let a_parts: Vec<&str> = a.split('/').collect();
+        let b_parts: Vec<&str> = b.split('/').collect();
+        let mut common_len = 0;
+        for (x, y) in a_parts.iter().zip(b_parts.iter()) {
+            if x == y {
+                common_len += 1;
+            } else {
+                break;
+            }
+        }
+        let parent = if common_len > 0 {
+            a_parts[..common_len].join("/")
+        } else {
+            String::new()
+        };
+        if !parent.is_empty() {
+            *dir_severity.entry(parent).or_insert(0.0) += v.severity;
+        }
+    }
+
+    let mut root = Node {
+        name: "root".to_string(),
+        value: None,
+        score: None,
+        children: Vec::new(),
+    };
+
+    for m in modules {
+        let rel = strip_prefix(&m.path, &common);
+        let parts: Vec<&str> = rel.split('/').collect();
+        let mut current = &mut root;
+
+        for (i, part) in parts.iter().enumerate() {
+            let is_leaf = i == parts.len() - 1;
+            let idx = current.children.iter().position(|c| c.name == *part);
+            if let Some(idx) = idx {
+                current = &mut current.children[idx];
+            } else {
+                // Compute score for this directory level
+                let dir_path = parts[..=i].join("/");
+                let node_score = if !is_leaf {
+                    let files = *dir_files.get(&dir_path).unwrap_or(&1) as f64;
+                    let sev = *dir_severity.get(&dir_path).unwrap_or(&0.0);
+                    Some((100.0 * (1.0 - sev / files.max(1.0))).clamp(0.0, 100.0))
+                } else {
+                    None
+                };
+
+                current.children.push(Node {
+                    name: part.to_string(),
+                    value: if is_leaf { Some(1) } else { None },
+                    score: node_score,
+                    children: Vec::new(),
+                });
+                let len = current.children.len();
+                current = &mut current.children[len - 1];
+            }
+        }
+    }
+
+    serde_json::to_value(root).unwrap_or(serde_json::json!({}))
+}
+
+fn build_sunburst_deps(
+    modules: &[Module],
+    dependencies: &[Dependency],
+    id_to_path: &HashMap<&str, &str>,
+) -> Vec<DepEdge> {
+    let paths: Vec<&str> = modules.iter().map(|m| m.path.as_str()).collect();
+    let common = find_common_prefix(&paths);
+    let mut seen = std::collections::HashSet::new();
+    let mut deps = Vec::new();
+
+    for dep in dependencies {
+        let from = id_to_path.get(dep.from_module_id.as_str());
+        let to = id_to_path.get(dep.to_module_id.as_str());
+        if let (Some(&f), Some(&t)) = (from, to) {
+            let f_rel = strip_prefix(f, &common);
+            let t_rel = strip_prefix(t, &common);
+            let f_dir = f_rel.rsplit_once('/').map(|(d, _)| d).unwrap_or("");
+            let t_dir = t_rel.rsplit_once('/').map(|(d, _)| d).unwrap_or("");
+            if f_dir != t_dir && seen.insert((f_rel.clone(), t_rel.clone())) {
+                deps.push(DepEdge {
+                    from: f_rel,
+                    to: t_rel,
+                });
+            }
+        }
+    }
+    deps
+}
+
+/// Strip the full common directory prefix (all shared components).
+fn find_full_common_prefix(paths: &[&str]) -> String {
+    if paths.is_empty() {
+        return String::new();
+    }
+    let first: Vec<&str> = paths[0].split('/').collect();
+    let mut len = first.len().saturating_sub(1); // exclude filename
+    for path in &paths[1..] {
+        let parts: Vec<&str> = path.split('/').collect();
+        let mut common = 0;
+        for (a, b) in first.iter().zip(parts.iter()) {
+            if a == b {
+                common += 1;
+            } else {
+                break;
+            }
+        }
+        len = len.min(common);
+    }
+    first[..len].join("/")
+}
+
+fn find_common_prefix(paths: &[&str]) -> String {
+    if paths.is_empty() {
+        return String::new();
+    }
+    let first: Vec<&str> = paths[0].split('/').collect();
+    let mut len = first.len().saturating_sub(1);
+    for path in &paths[1..] {
+        let parts: Vec<&str> = path.split('/').collect();
+        let mut common = 0;
+        for (a, b) in first.iter().zip(parts.iter()) {
+            if a == b {
+                common += 1;
+            } else {
+                break;
+            }
+        }
+        len = len.min(common);
+    }
+    if len > 1 {
+        len -= 1;
+    }
+    first[..len].join("/")
+}
+
+fn strip_prefix(path: &str, prefix: &str) -> String {
+    if prefix.is_empty() {
+        return path.to_string();
+    }
+    let with_slash = format!("{}/", prefix);
+    path.strip_prefix(&with_slash).unwrap_or(path).to_string()
+}

--- a/src/reporter/dashboard_template.html
+++ b/src/reporter/dashboard_template.html
@@ -1,0 +1,414 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>noupling — Architecture Dashboard</title>
+<style>
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif; background: #fff; color: #1e293b; }}
+.header {{ background: #f8fafc; border-bottom: 1px solid #e2e8f0; padding: 1.25rem 2rem; display: flex; align-items: center; justify-content: space-between; }}
+.header h1 {{ font-size: 1.1rem; font-weight: 600; }}
+.header h1 span {{ color: #3b82f6; }}
+.header .score-badge {{ font-size: 2rem; font-weight: 800; }}
+.score-green {{ color: #16a34a; }}
+.score-yellow {{ color: #ca8a04; }}
+.score-red {{ color: #dc2626; }}
+.header .meta {{ font-size: 0.75rem; color: #94a3b8; }}
+.container {{ max-width: 1200px; margin: 0 auto; padding: 1.5rem 2rem; }}
+.cards {{ display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; margin-bottom: 2rem; }}
+.card {{ background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1rem 1.25rem; }}
+.card .label {{ font-size: 0.7rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }}
+.card .value {{ font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; }}
+.card .detail {{ font-size: 0.75rem; color: #64748b; margin-top: 0.15rem; }}
+section {{ margin-bottom: 2.5rem; }}
+section h2 {{ font-size: 1.1rem; font-weight: 700; margin-bottom: 1rem; color: #334155; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.5rem; }}
+table {{ width: 100%; border-collapse: collapse; font-size: 0.8rem; }}
+th {{ text-align: left; padding: 0.5rem 0.75rem; background: #f8fafc; color: #64748b; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; cursor: pointer; user-select: none; border-bottom: 2px solid #e2e8f0; }}
+th:hover {{ color: #334155; }}
+td {{ padding: 0.5rem 0.75rem; border-bottom: 1px solid #f1f5f9; }}
+tr:hover {{ background: #f8fafc; }}
+.score-cell {{ font-weight: 600; }}
+.charts-row {{ display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-bottom: 2rem; }}
+.chart-box {{ background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.25rem; }}
+.chart-box h3 {{ font-size: 0.85rem; font-weight: 600; color: #475569; margin-bottom: 0.75rem; }}
+.bar {{ display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.4rem; font-size: 0.8rem; }}
+.bar-fill {{ height: 20px; border-radius: 3px; min-width: 2px; }}
+.quick-wins {{ list-style: none; }}
+.quick-wins li {{ padding: 0.4rem 0; border-bottom: 1px solid #f1f5f9; font-size: 0.8rem; display: flex; justify-content: space-between; }}
+.quick-wins .cost {{ font-weight: 600; color: #16a34a; }}
+.quick-wins .type {{ font-size: 0.7rem; color: #94a3b8; }}
+.sunburst-container {{ display: flex; justify-content: center; }}
+.risk-container {{ position: relative; }}
+.risk-label {{ position: absolute; font-size: 0.65rem; color: #cbd5e1; font-weight: 500; }}
+.depth-chain {{ display: flex; align-items: center; gap: 0.25rem; flex-wrap: wrap; font-size: 0.8rem; }}
+.depth-node {{ background: #e2e8f0; padding: 0.2rem 0.5rem; border-radius: 4px; font-weight: 500; }}
+.depth-arrow {{ color: #94a3b8; }}
+.tooltip {{ position: fixed; background: #1e293b; color: #e2e8f0; border-radius: 6px; padding: 0.4rem 0.65rem; font-size: 0.7rem; pointer-events: none; opacity: 0; z-index: 100; }}
+footer {{ text-align: center; font-size: 0.65rem; color: #cbd5e1; padding: 1rem; border-top: 1px solid #e2e8f0; }}
+@media print {{ .header {{ background: #fff; }} .card {{ break-inside: avoid; }} }}
+@media (max-width: 768px) {{ .cards {{ grid-template-columns: repeat(2, 1fr); }} .charts-row {{ grid-template-columns: 1fr; }} }}
+</style>
+</head>
+<body>
+
+<div class="header">
+    <div>
+        <h1><span>nou</span>pling</h1>
+        <div class="meta">Architecture Dashboard</div>
+    </div>
+    <div style="text-align: right">
+        <div class="score-badge" id="score-badge"></div>
+        <div class="meta" id="meta-info"></div>
+    </div>
+</div>
+
+<div class="container">
+
+<!-- Section 1: Metric Cards -->
+<div class="cards" id="cards"></div>
+
+<!-- Section 2: Module Scorecard -->
+<section>
+    <h2>Module Scorecard</h2>
+    <table id="module-table">
+        <thead><tr>
+            <th data-sort="name">Module</th>
+            <th data-sort="score">Score</th>
+            <th data-sort="file_count">Files</th>
+            <th data-sort="violations">Violations</th>
+            <th data-sort="circular">Circular</th>
+            <th data-sort="xs">XS</th>
+            <th data-sort="independence">Independence</th>
+            <th data-sort="instability">Instability</th>
+        </tr></thead>
+        <tbody id="module-tbody"></tbody>
+    </table>
+</section>
+
+<!-- Charts Row -->
+<div class="charts-row">
+    <!-- Section 5: Risk Matrix -->
+    <div class="chart-box">
+        <h3>Risk Matrix (Instability vs Blast Radius)</h3>
+        <div class="risk-container" id="risk-chart"></div>
+    </div>
+
+    <!-- Section 6: Violations -->
+    <div class="chart-box">
+        <h3>Violations</h3>
+        <div id="violation-charts"></div>
+    </div>
+</div>
+
+<div class="charts-row">
+    <!-- Section 3: Sunburst -->
+    <div class="chart-box">
+        <h3>Architecture Map</h3>
+        <div class="sunburst-container" id="sunburst"></div>
+    </div>
+
+    <!-- Section 7: Depth + Quick Wins -->
+    <div class="chart-box">
+        <h3>Dependency Depth &amp; Quick Wins</h3>
+        <div id="depth-section"></div>
+    </div>
+</div>
+
+</div>
+
+<footer>{version}</footer>
+
+<div id="tooltip" class="tooltip"></div>
+
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script>
+const D = {json};
+const tooltip = document.getElementById("tooltip");
+
+// ── Score badge ──
+const scoreBadge = document.getElementById("score-badge");
+const cls = D.score >= 90 ? "score-green" : D.score >= 70 ? "score-yellow" : "score-red";
+scoreBadge.className = "score-badge " + cls;
+scoreBadge.textContent = D.score.toFixed(1) + "/100";
+document.getElementById("meta-info").textContent = D.total_modules + " modules · " + D.total_violations + " violations";
+
+// ── Metric cards ──
+const cardsHtml = [
+    {{ label: "Health Score", value: D.score.toFixed(1), detail: "out of 100" }},
+    {{ label: "Total XS", value: D.total_xs, detail: "imports to remove" }},
+    {{ label: "Lowest Independence", value: D.lowest_independence ? (D.lowest_independence.score * 100).toFixed(0) + "%" : "—", detail: D.lowest_independence ? D.lowest_independence.name : "all independent" }},
+    {{ label: "Highest Blast Radius", value: D.highest_blast ? D.highest_blast.blast_radius : "0", detail: D.highest_blast ? D.highest_blast.name : "no risk" }},
+].map(c => `<div class="card"><div class="label">${{c.label}}</div><div class="value">${{c.value}}</div><div class="detail">${{c.detail}}</div></div>`).join("");
+document.getElementById("cards").innerHTML = cardsHtml;
+
+// ── Module scorecard ──
+let sortKey = "score";
+let sortAsc = true;
+
+function renderTable() {{
+    const sorted = [...D.modules_table].sort((a, b) => {{
+        const va = a[sortKey], vb = b[sortKey];
+        return sortAsc ? (va < vb ? -1 : va > vb ? 1 : 0) : (va > vb ? -1 : va < vb ? 1 : 0);
+    }});
+    const tbody = document.getElementById("module-tbody");
+    tbody.innerHTML = sorted.map(m => {{
+        const sc = m.score >= 90 ? "score-green" : m.score >= 70 ? "score-yellow" : "score-red";
+        return `<tr>
+            <td><strong>${{m.name}}</strong></td>
+            <td class="score-cell ${{sc}}">${{m.score.toFixed(1)}}</td>
+            <td>${{m.file_count}}</td>
+            <td>${{m.violations || "—"}}</td>
+            <td>${{m.circular || "—"}}</td>
+            <td>${{m.xs || "—"}}</td>
+            <td>${{(m.independence * 100).toFixed(0)}}%</td>
+            <td>${{m.instability.toFixed(2)}}</td>
+        </tr>`;
+    }}).join("");
+}}
+renderTable();
+
+document.querySelectorAll("#module-table th").forEach(th => {{
+    th.addEventListener("click", () => {{
+        const key = th.dataset.sort;
+        if (sortKey === key) sortAsc = !sortAsc;
+        else {{ sortKey = key; sortAsc = key === "name"; }}
+        renderTable();
+    }});
+}});
+
+// ── Risk Matrix ──
+(function() {{
+    const data = D.risk_matrix;
+    if (!data.length) return;
+    const w = 350, h = 250, pad = {{ top: 10, right: 20, bottom: 35, left: 45 }};
+    const svg = d3.select("#risk-chart").append("svg").attr("width", w).attr("height", h);
+    const maxBlast = d3.max(data, d => d.blast_radius) || 10;
+
+    const x = d3.scaleLinear().domain([0, 1]).range([pad.left, w - pad.right]);
+    const y = d3.scaleLinear().domain([0, maxBlast * 1.1]).range([h - pad.bottom, pad.top]);
+    const r = d3.scaleSqrt().domain([1, d3.max(data, d => d.file_count) || 10]).range([4, 20]);
+
+    svg.append("g").attr("transform", `translate(0,${{h - pad.bottom}})`).call(d3.axisBottom(x).ticks(5)).selectAll("text").style("font-size", "9px");
+    svg.append("g").attr("transform", `translate(${{pad.left}},0)`).call(d3.axisLeft(y).ticks(5)).selectAll("text").style("font-size", "9px");
+
+    // Quadrant labels
+    svg.append("text").attr("x", pad.left + 5).attr("y", pad.top + 12).text("Zone of Pain").style("font-size", "8px").style("fill", "#fca5a5");
+    svg.append("text").attr("x", w - pad.right - 40).attr("y", h - pad.bottom - 5).text("Safe").style("font-size", "8px").style("fill", "#86efac");
+
+    // Quadrant line
+    svg.append("line").attr("x1", x(0.5)).attr("y1", pad.top).attr("x2", x(0.5)).attr("y2", h - pad.bottom).attr("stroke", "#e2e8f0").attr("stroke-dasharray", "3,3");
+
+    svg.selectAll("circle").data(data).join("circle")
+        .attr("cx", d => x(d.instability))
+        .attr("cy", d => y(d.blast_radius))
+        .attr("r", d => r(d.file_count))
+        .attr("fill", d => d.score >= 90 ? "#86efac" : d.score >= 70 ? "#fde68a" : "#fca5a5")
+        .attr("stroke", "#fff")
+        .attr("stroke-width", 1)
+        .attr("opacity", 0.8)
+        .on("mouseover", (e, d) => {{
+            tooltip.innerHTML = `<strong>${{d.name}}</strong><br>I=${{d.instability.toFixed(2)}} · Blast=${{d.blast_radius}} · ${{d.file_count}} files`;
+            tooltip.style.opacity = 1;
+        }})
+        .on("mousemove", e => {{ tooltip.style.left = (e.clientX + 10) + "px"; tooltip.style.top = (e.clientY - 10) + "px"; }})
+        .on("mouseout", () => {{ tooltip.style.opacity = 0; }});
+
+    svg.append("text").attr("x", w / 2).attr("y", h - 2).text("Instability →").style("font-size", "9px").style("fill", "#94a3b8").style("text-anchor", "middle");
+    svg.append("text").attr("transform", "rotate(-90)").attr("x", -h / 2).attr("y", 12).text("Blast Radius →").style("font-size", "9px").style("fill", "#94a3b8").style("text-anchor", "middle");
+}})();
+
+// ── Violation charts ──
+(function() {{
+    const el = document.getElementById("violation-charts");
+    const maxAge = Math.max(D.violation_age.new_count, D.violation_age.recent_count, D.violation_age.chronic_count, 1);
+    const maxType = Math.max(D.violation_types.coupling, D.violation_types.circular, 1);
+
+    let html = '<div style="margin-bottom:1rem"><div style="font-size:0.75rem;color:#64748b;margin-bottom:0.4rem;font-weight:600">By Age</div>';
+    [["New", D.violation_age.new_count, "#3b82f6"], ["Recent", D.violation_age.recent_count, "#f59e0b"], ["Chronic", D.violation_age.chronic_count, "#ef4444"]].forEach(([label, count, color]) => {{
+        const w = Math.max((count / maxAge) * 200, count > 0 ? 2 : 0);
+        html += `<div class="bar"><span style="width:55px">${{label}}</span><div class="bar-fill" style="width:${{w}}px;background:${{color}}"></div><span>${{count}}</span></div>`;
+    }});
+
+    html += '</div><div style="margin-bottom:1rem"><div style="font-size:0.75rem;color:#64748b;margin-bottom:0.4rem;font-weight:600">By Type</div>';
+    [["Coupling", D.violation_types.coupling, "#f59e0b"], ["Circular", D.violation_types.circular, "#ef4444"]].forEach(([label, count, color]) => {{
+        const w = Math.max((count / maxType) * 200, count > 0 ? 2 : 0);
+        html += `<div class="bar"><span style="width:55px">${{label}}</span><div class="bar-fill" style="width:${{w}}px;background:${{color}}"></div><span>${{count}}</span></div>`;
+    }});
+
+    html += '</div><div><div style="font-size:0.75rem;color:#64748b;margin-bottom:0.4rem;font-weight:600">Quick Wins (lowest cost to fix)</div><ul class="quick-wins">';
+    D.quick_wins.forEach(w => {{
+        html += `<li><span>${{w.from}} → ${{w.to}} <span class="type">${{w.is_circular ? "circular" : "coupling"}}</span></span><span class="cost">${{w.cost}} import${{w.cost !== 1 ? "s" : ""}}</span></li>`;
+    }});
+    if (!D.quick_wins.length) html += '<li style="color:#94a3b8">No violations</li>';
+    html += '</ul></div>';
+    el.innerHTML = html;
+}})();
+
+// ── Sunburst with health-score colors and dependency edges ──
+(function() {{
+    const w = 400, radius = w / 6;
+    const allDeps = D.sunburst_deps;
+    let currentZoomNode = null;
+
+    const root = d3.hierarchy(D.sunburst_tree).sum(d => d.value || 0).sort((a, b) => b.value - a.value);
+    d3.partition().size([2 * Math.PI, root.height + 1])(root);
+
+    // Assign full paths and current state
+    root.each(d => {{
+        const parts = d.ancestors().reverse().slice(1).map(n => n.data.name);
+        d.fullPath = parts.join("/");
+        d.current = {{ x0: d.x0, x1: d.x1, y0: d.y0, y1: d.y1 }};
+    }});
+    currentZoomNode = root;
+
+    const arc = d3.arc().startAngle(d => d.x0).endAngle(d => d.x1)
+        .padAngle(d => Math.min((d.x1 - d.x0) / 2, 0.005)).padRadius(radius * 1.5)
+        .innerRadius(d => d.y0 * radius).outerRadius(d => Math.max(d.y0 * radius, d.y1 * radius - 1));
+
+    const svg = d3.select("#sunburst").append("svg").attr("viewBox", [-w/2, -w/2, w, w]).attr("width", w).attr("height", w).style("font", "9px sans-serif");
+
+    // Score-based color
+    function fillColor(d) {{
+        let node = d;
+        while (node) {{
+            if (node.data.score != null) {{
+                const s = node.data.score;
+                if (s >= 90) return d.children ? "rgba(34,197,94,0.5)" : "rgba(34,197,94,0.3)";
+                if (s >= 70) return d.children ? "rgba(234,179,8,0.5)" : "rgba(234,179,8,0.3)";
+                return d.children ? "rgba(239,68,68,0.45)" : "rgba(239,68,68,0.25)";
+            }}
+            node = node.parent;
+        }}
+        let top = d; while (top.depth > 1) top = top.parent;
+        const color = d3.scaleOrdinal(d3.quantize(d3.interpolateRainbow, (root.children || []).length + 1));
+        const c = d3.color(color(top.data.name)); c.opacity = d.children ? 0.6 : 0.4; return c + "";
+    }}
+
+    function arcVisible(d) {{ return d.y1 <= 3 && d.y0 >= 1 && d.x1 > d.x0; }}
+    function labelVisible(d) {{ return d.y1 <= 3 && d.y0 >= 1 && (d.y1 - d.y0) * (d.x1 - d.x0) > 0.03; }}
+    function labelTransform(d) {{ const x = (d.x0 + d.x1) / 2 * 180 / Math.PI; const y = (d.y0 + d.y1) / 2 * radius; return `rotate(${{x - 90}}) translate(${{y}},0) rotate(${{x < 180 ? 0 : 180}})`; }}
+
+    const path = svg.append("g").selectAll("path").data(root.descendants().slice(1)).join("path")
+        .attr("fill", d => fillColor(d)).attr("fill-opacity", d => arcVisible(d.current) ? 1 : 0)
+        .attr("pointer-events", d => arcVisible(d.current) ? "auto" : "none").attr("d", d => arc(d.current));
+    path.filter(d => d.children).style("cursor", "pointer").on("click", clicked);
+    path.append("title").text(d => d.ancestors().map(d => d.data.name).reverse().slice(1).join("/") + "\n" + d.value + " files");
+
+    const label = svg.append("g").attr("pointer-events", "none").attr("text-anchor", "middle").style("user-select", "none")
+        .selectAll("text").data(root.descendants().slice(1)).join("text")
+        .attr("dy", "0.35em").attr("fill", "#374151").attr("fill-opacity", d => +labelVisible(d.current)).attr("transform", d => labelTransform(d.current)).text(d => d.data.name);
+
+    const parentCircle = svg.append("circle").datum(root).attr("r", radius).attr("fill", "#f8fafc").attr("stroke", "#e2e8f0").style("cursor", "pointer").on("click", clicked);
+
+    // Edge group (on top)
+    const edgeGroup = svg.append("g");
+
+    // Dependency edge drawing
+    function findOwner(filePath, children) {{
+        for (const child of children) {{
+            if (filePath === child.fullPath || filePath.startsWith(child.fullPath + "/")) return child;
+        }}
+        return null;
+    }}
+
+    // Build violation lookup set
+    const violationDeps = D.sunburst_violation_deps || [];
+    const vSet = new Set();
+    for (const vd of violationDeps) {{
+        const from = findOwner(vd.from, root.children || []);
+        const to = findOwner(vd.to, root.children || []);
+        if (from && to) vSet.add(from.fullPath + "|" + to.fullPath);
+    }}
+
+    function drawEdges() {{
+        const children = currentZoomNode.children || [];
+        edgeGroup.selectAll("path").remove();
+        if (children.length === 0) return;
+
+        // Rebuild violation set for current zoom level
+        const localVSet = new Set();
+        for (const vd of violationDeps) {{
+            const from = findOwner(vd.from, children);
+            const to = findOwner(vd.to, children);
+            if (from && to && from !== to) localVSet.add(from.fullPath + "|" + to.fullPath);
+        }}
+
+        const edgeMap = new Map();
+        for (const dep of allDeps) {{
+            const from = findOwner(dep.from, children);
+            const to = findOwner(dep.to, children);
+            if (from && to && from !== to) {{
+                const key = from.fullPath + "|" + to.fullPath;
+                if (!edgeMap.has(key)) edgeMap.set(key, {{ from, to, count: 0, isViolation: localVSet.has(key) }});
+                edgeMap.get(key).count++;
+            }}
+        }}
+
+        edgeGroup.selectAll("path").data(Array.from(edgeMap.values())).join("path")
+            .attr("fill", "none")
+            .attr("stroke", d => d.isViolation ? "#ef4444" : "#94a3b8")
+            .attr("stroke-opacity", d => d.isViolation ? 0.25 : 0.12)
+            .attr("stroke-width", 1)
+            .style("pointer-events", "stroke")
+            .attr("d", d => {{
+                const a1 = (d.from.current.x0 + d.from.current.x1) / 2;
+                const r1 = d.from.current.y0 * radius;
+                const a2 = (d.to.current.x0 + d.to.current.x1) / 2;
+                const r2 = d.to.current.y0 * radius;
+                const x1 = Math.sin(a1) * r1, y1 = -Math.cos(a1) * r1;
+                const x2 = Math.sin(a2) * r2, y2 = -Math.cos(a2) * r2;
+                const cx = 0.15 * (x1 + x2) / 2, cy = 0.15 * (y1 + y2) / 2;
+                return `M${{x1}},${{y1}} Q${{cx}},${{cy}} ${{x2}},${{y2}}`;
+            }})
+            .on("mouseover", (e, d) => {{
+                const type = d.isViolation ? ' · <span style="color:#ef4444">violation</span>' : "";
+                tooltip.innerHTML = `<strong>${{d.from.data.name}}</strong> → <strong>${{d.to.data.name}}</strong><br>${{d.count}} import${{d.count !== 1 ? "s" : ""}}${{type}}`;
+                tooltip.style.opacity = 1;
+                d3.select(e.target).attr("stroke", d.isViolation ? "#ef4444" : "#3b82f6").attr("stroke-opacity", 0.7).attr("stroke-width", 2);
+            }})
+            .on("mousemove", e => {{ tooltip.style.left = (e.clientX + 10) + "px"; tooltip.style.top = (e.clientY - 10) + "px"; }})
+            .on("mouseout", (e, d) => {{
+                tooltip.style.opacity = 0;
+                d3.select(e.target)
+                    .attr("stroke", d.isViolation ? "#ef4444" : "#94a3b8")
+                    .attr("stroke-opacity", d.isViolation ? 0.25 : 0.12)
+                    .attr("stroke-width", 1);
+            }});
+    }}
+
+    drawEdges();
+
+    function clicked(event, p) {{
+        parentCircle.datum(p.parent || root);
+        currentZoomNode = p;
+        root.each(d => d.target = {{ x0: Math.max(0, Math.min(1, (d.x0 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI, x1: Math.max(0, Math.min(1, (d.x1 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI, y0: Math.max(0, d.y0 - p.depth), y1: Math.max(0, d.y1 - p.depth) }});
+        edgeGroup.selectAll("path").remove();
+        const t = svg.transition().duration(750);
+        path.transition(t).tween("data", d => {{ const i = d3.interpolate(d.current, d.target); return t => d.current = i(t); }})
+            .filter(function(d) {{ return +this.getAttribute("fill-opacity") || arcVisible(d.target); }})
+            .attr("fill-opacity", d => arcVisible(d.target) ? 1 : 0).attr("pointer-events", d => arcVisible(d.target) ? "auto" : "none").attrTween("d", d => () => arc(d.current));
+        label.filter(function(d) {{ return +this.getAttribute("fill-opacity") || labelVisible(d.target); }}).transition(t)
+            .attr("fill-opacity", d => +labelVisible(d.target)).attrTween("transform", d => () => labelTransform(d.current));
+        t.end().then(() => drawEdges()).catch(() => {{}});
+    }}
+}})();
+
+// ── Depth & Critical Path ──
+(function() {{
+    const el = document.getElementById("depth-section");
+    let html = `<div style="margin-bottom:1rem"><div style="font-size:0.75rem;color:#64748b;margin-bottom:0.4rem;font-weight:600">Maximum Depth: <span style="color:#1e293b;font-size:1.1rem">${{D.max_depth}}</span></div>`;
+    if (D.critical_path.length > 0) {{
+        html += '<div style="font-size:0.75rem;color:#64748b;margin-bottom:0.4rem">Critical Path:</div><div class="depth-chain">';
+        D.critical_path.forEach((p, i) => {{
+            if (i > 0) html += '<span class="depth-arrow">→</span>';
+            html += `<span class="depth-node">${{p}}</span>`;
+        }});
+        html += '</div>';
+    }}
+    html += '</div>';
+    el.innerHTML = html;
+}})();
+</script>
+</body>
+</html>

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -38,12 +38,10 @@ struct ReportData {
     dirs: BTreeMap<String, DirNode>,
     root_path: String,
     snapshot_id: String,
-    #[allow(dead_code)]
     total_score: f64,
-    #[allow(dead_code)]
     total_modules: usize,
-    #[allow(dead_code)]
     total_violations: usize,
+    total_xs: usize,
     score_green: f64,
     score_yellow: f64,
     critical_severity: f64,
@@ -304,6 +302,7 @@ fn build_report_data(
         total_score: result.score,
         total_modules: result.total_modules,
         total_violations: result.violations.len(),
+        total_xs: result.total_xs,
         score_green: settings.thresholds.score_green,
         score_yellow: settings.thresholds.score_yellow,
         critical_severity: settings.thresholds.critical_severity,
@@ -413,6 +412,22 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
 
     let breadcrumbs = build_breadcrumbs(dir_path, &data.root_path);
     let score_clr = score_color(dir.score, data.score_green, data.score_yellow);
+
+    let is_root = dir_path == data.root_path;
+    let project_banner = if is_root {
+        let banner_clr = score_color(data.total_score, data.score_green, data.score_yellow);
+        format!(
+            "<div class=\"summary\" style=\"background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:0.75rem 1rem;margin-bottom:1rem\">
+                <div class=\"summary-card\"><div class=\"label\">Project Score</div><div class=\"value\" style=\"color:{}\">{:.1}</div></div>
+                <div class=\"summary-card\"><div class=\"label\">Total Modules</div><div class=\"value\">{}</div></div>
+                <div class=\"summary-card\"><div class=\"label\">Total Violations</div><div class=\"value\">{}</div></div>
+                <div class=\"summary-card\"><div class=\"label\">Total XS</div><div class=\"value\">{}</div></div>
+            </div>",
+            banner_clr, data.total_score, data.total_modules, data.total_violations, data.total_xs
+        )
+    } else {
+        String::new()
+    };
 
     let mut children_rows = String::new();
     for child_path in &dir.children_dirs {
@@ -595,6 +610,8 @@ details[open] summary.cycle-path::before {{ transform: rotate(90deg); }}
 <h1>{title}</h1>
 <p class="snapshot">Snapshot: {snapshot_id}</p>
 
+{project_banner}
+
 <div class="summary">
     <div class="summary-card">
         <div class="label">Health Score</div>
@@ -624,6 +641,7 @@ details[open] summary.cycle-path::before {{ transform: rotate(90deg); }}
         title = title,
         breadcrumbs = breadcrumbs,
         snapshot_id = data.snapshot_id,
+        project_banner = project_banner,
         score_clr = score_clr,
         score = dir.score,
         modules = dir.module_count,

--- a/src/reporter/md.rs
+++ b/src/reporter/md.rs
@@ -125,6 +125,15 @@ fn render_dir_page(
             if report.total_xs == 1 { "" } else { "s" }
         ));
     }
+    if is_root && report.max_depth > 0 {
+        md.push_str(&format!(
+            "| Max Dependency Depth | {} |\n",
+            report.max_depth
+        ));
+    }
+    if is_root && report.suppressed_count > 0 {
+        md.push_str(&format!("| Suppressed | {} |\n", report.suppressed_count));
+    }
     md.push('\n');
 
     // Contents: child directories

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1,4 +1,5 @@
 mod bundle;
+mod dashboard;
 mod graph;
 mod html;
 mod md;
@@ -10,6 +11,7 @@ use crate::analyzer::{AuditResult, CouplingViolation};
 use crate::core::Module;
 
 pub use bundle::generate_bundle_report;
+pub use dashboard::generate_dashboard;
 pub use graph::{format_dot, format_mermaid};
 pub use html::generate_html_report;
 pub use md::generate_markdown_report;
@@ -26,7 +28,9 @@ pub struct JsonReport {
     pub score: f64,
     pub total_modules: usize,
     pub total_xs: usize,
+    pub max_depth: usize,
     pub suppressed_count: usize,
+    pub violation_age: JsonViolationAge,
     pub critical_violations: usize,
     pub total_circular: usize,
     pub total_coupling: usize,
@@ -34,6 +38,13 @@ pub struct JsonReport {
     pub coupling_violations: Vec<JsonCouplingViolation>,
     pub hotspots: Vec<JsonHotspot>,
     pub directory_tree: Vec<JsonDirectory>,
+}
+
+#[derive(Serialize)]
+pub struct JsonViolationAge {
+    pub new_count: usize,
+    pub recent_count: usize,
+    pub chronic_count: usize,
 }
 
 #[derive(Serialize)]
@@ -194,7 +205,13 @@ impl JsonReport {
             score: result.score,
             total_modules: result.total_modules,
             total_xs: result.total_xs,
+            max_depth: result.max_depth,
             suppressed_count: result.suppressed_count,
+            violation_age: JsonViolationAge {
+                new_count: result.violation_age.new_count,
+                recent_count: result.violation_age.recent_count,
+                chronic_count: result.violation_age.chronic_count,
+            },
             critical_violations,
             total_circular: circular.len(),
             total_coupling: coupling.len(),
@@ -388,9 +405,11 @@ pub fn format_xml(modules: &[Module], result: &AuditResult, snapshot_id: &str) -
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     xml.push_str(&format!(
-        "<noupling-report generator=\"{}\" snapshot=\"{}\" score=\"{:.2}\" totalModules=\"{}\" totalXs=\"{}\" criticalViolations=\"{}\" totalCircular=\"{}\" totalCoupling=\"{}\">\n",
+        "<noupling-report generator=\"{}\" snapshot=\"{}\" score=\"{:.2}\" totalModules=\"{}\" totalXs=\"{}\" maxDepth=\"{}\" suppressedCount=\"{}\" violationAgeNew=\"{}\" violationAgeRecent=\"{}\" violationAgeChronic=\"{}\" criticalViolations=\"{}\" totalCircular=\"{}\" totalCoupling=\"{}\">\n",
         xml_escape(VERSION), xml_escape(&report.snapshot_id), report.score, report.total_modules,
-        report.total_xs, report.critical_violations, report.total_circular, report.total_coupling,
+        report.total_xs, report.max_depth, report.suppressed_count,
+        report.violation_age.new_count, report.violation_age.recent_count, report.violation_age.chronic_count,
+        report.critical_violations, report.total_circular, report.total_coupling,
     ));
 
     // Circular dependencies


### PR DESCRIPTION
## Summary

Self-contained HTML dashboard for CTOs and tech leads: `noupling report . --format dashboard`

### Dashboard sections
- **Score badge** with project-level health score
- **4 metric cards**: Health Score, Total XS, Lowest Independence, Highest Blast Radius
- **Sortable module scorecard** table (click column headers)
- **Risk matrix** scatter plot: Instability vs Blast Radius (dot size = files, color = score)
- **Zoomable sunburst** with health-score colors (green/yellow/red) and dependency edges
- **Violation charts**: by age (new/recent/chronic), by type (coupling/circular), quick wins
- **Dependency depth** with critical path

### Also updates existing reports
- **HTML**: project-level banner on root page (score, modules, violations, XS)
- **JSON**: adds `max_depth` and `violation_age` fields
- **XML**: adds `maxDepth`, `violationAge*` attributes
- **Markdown**: adds max depth and suppressed count to root summary

## Test plan
- [x] 185 tests pass
- [x] clippy clean
- [x] fmt clean
- [x] Tested with 1147-module Android project

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)