### PR TITLE
fix: use explicit width on logo img

### DIFF
--- a/docs/style.css
+++ b/docs/style.css
@@ -74,7 +74,7 @@ nav .logo {
 
 nav .logo img {
   height: 24px;
-  width: auto;
+  width: 103px;
   display: block;
 }
 


### PR DESCRIPTION
Logo was rendering at 0×0 because the SVG has width=100% height=100% and width: auto can't derive a value from the viewBox alone. Set explicit width: 103px to match the 202:47 viewBox ratio at 24px height.