### PR TITLE
release: v0.5.0 — The Tech Lead Release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "noupling"
-version = "0.4.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Per-Erik Bergman"]
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -29,13 +29,16 @@ Every violation gets a **severity score** based on depth: problems at the root o
 - **14 languages**: C#, Dart, Go, Haskell, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Swift, TypeScript, Zig
 - **Tree-sitter parsing**: Fast, accurate AST-based import extraction (no regex)
 - **Parallel scanning**: Rayon-powered file discovery and parsing
-- **8 report formats**: JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Sunburst
+- **9 report formats**: JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Sunburst, Dashboard (or `all` to generate every format)
 - **Interactive HTML report**: Kover-style drill-down with color-coded scores
 - **Sunburst visualization**: Zoomable D3.js dependency graph with animated drill-down
+- **Technical Leader Dashboard**: Single-page executive view with all metrics, sortable scorecard, risk matrix
 - **Monorepo support**: Independent analysis per module with cross-module dependency validation
 - **Architectural layers**: Define dependency direction, suppress legitimate downward coupling
 - **XS metric**: Quantify refactoring cost per violation, find the weakest link in cycles
 - **Inline suppression**: `// noupling:ignore` to suppress known acceptable coupling
+- **Advanced metrics**: Module independence, blast radius, instability (Martin's I), dependency depth, violation age
+- **Per-module trends**: `--by-module` flag to track score evolution per directory across snapshots
 - **PR/CI mode**: `--diff-base main` to only flag new violations
 - **Configurable**: Thresholds, layers, dependency rules, glob ignore patterns
 
@@ -113,14 +116,16 @@ noupling audit /path/to/project --fail-below 80  # Exit code 1 if score < 80
 ### Generate reports
 
 ```bash
-noupling report /path/to/project --format json    # Comprehensive JSON
-noupling report /path/to/project --format xml     # Comprehensive XML
-noupling report /path/to/project --format md      # Multi-file navigable Markdown
-noupling report /path/to/project --format html    # Interactive HTML with drill-down
-noupling report /path/to/project --format sonar   # SonarCloud generic issue import
-noupling report /path/to/project --format mermaid # Mermaid flowchart diagram
-noupling report /path/to/project --format dot     # GraphViz DOT graph
-noupling report /path/to/project --format bundle  # Zoomable sunburst with dependency edges
+noupling report /path/to/project --format json      # Comprehensive JSON
+noupling report /path/to/project --format xml       # Comprehensive XML
+noupling report /path/to/project --format md        # Multi-file navigable Markdown
+noupling report /path/to/project --format html      # Interactive HTML with drill-down
+noupling report /path/to/project --format sonar     # SonarCloud generic issue import
+noupling report /path/to/project --format mermaid   # Mermaid flowchart diagram
+noupling report /path/to/project --format dot       # GraphViz DOT graph
+noupling report /path/to/project --format bundle    # Zoomable sunburst with dependency edges
+noupling report /path/to/project --format dashboard # Interactive Technical Leader Dashboard
+noupling report /path/to/project --format all       # Generate every format above in one command
 ```
 
 ### Diff mode (PR/CI gate)

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -17,7 +17,7 @@
       <li><a href="docs.html">Docs</a></li>
       <li><a href="changelog.html" class="active">Changelog</a></li>
       <li><a href="https://github.com/pererikbergman/noupling">GitHub</a></li>
-      <li><span class="badge">v0.4.1</span></li>
+      <li><span class="badge">v0.5.0</span></li>
     </ul>
   </div>
 </nav>
@@ -29,6 +29,43 @@
     <p class="lead">
       Not a commit log. A narrative of architectural decisions&mdash;what broke, what was built, and why each change exists.
     </p>
+
+    <!-- ── v0.5.0 ─────────────────────────────────────── -->
+    <article class="release">
+      <h2>v0.5.0 &mdash; The Tech Lead Release</h2>
+      <div class="date">April 2026</div>
+
+      <h3><span class="tag tag-feat">feat</span> Interactive Technical Leader Dashboard (<a href="https://github.com/pererikbergman/noupling/issues/132">#132</a>)</h3>
+      <p><strong>The friction:</strong> Engineers got rich, drillable HTML reports. CTOs and tech leads got... numbers in a terminal. The existing reports answered "where are the violations?" but not "is the architecture improving?", "which module is the riskiest to change?", or "what should we refactor first for the biggest impact?"</p>
+      <p><strong>The implementation:</strong> A self-contained HTML dashboard combining all v0.5.0 metrics: score badge, sortable scorecard table, risk matrix scatter plot (instability vs blast radius), zoomable sunburst with health-score colors and dependency edges, violation breakdowns by age and type, quick-win refactoring targets, and the dependency depth critical path.</p>
+      <p><strong>The ripple effect:</strong> noupling becomes presentable to executive audiences. The dashboard is the artifact you put in a quarterly review slide deck. Generate it, screenshot it, send it.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Module independence score (<a href="https://github.com/pererikbergman/noupling/issues/126">#126</a>)</h3>
+      <p>Per-module ratio of internal to total dependencies. Answers "Can team X own this module independently?" A module with 95% internal deps is ready to extract; one with 40% is deeply entangled.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Blast radius metric (<a href="https://github.com/pererikbergman/noupling/issues/127">#127</a>)</h3>
+      <p>For each module, the count of other modules transitively affected by changes. BFS on the reverse dependency graph. Top 10 highest blast radius shown in audit. Critical for change risk assessment.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Instability metric &mdash; Martin's I (<a href="https://github.com/pererikbergman/noupling/issues/128">#128</a>)</h3>
+      <p>Classic <code>I = fan_out / (fan_in + fan_out)</code>. Includes Zone of Pain detection: stable modules (I &lt; 0.3) with high fan-in are foundational but hard to change.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Coupling trend per area (<a href="https://github.com/pererikbergman/noupling/issues/129">#129</a>)</h3>
+      <p>The <code>--by-module</code> flag on the trend command shows per-directory health scores across snapshots, with +/- indicators. "The payment module went from 82 to 67 over the last 6 sprints" &mdash; now visible.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Dependency depth and critical path (<a href="https://github.com/pererikbergman/noupling/issues/130">#130</a>)</h3>
+      <p>The longest transitive dependency chain in the project, computed via topological sort. Deep chains mean changes ripple through many layers.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Violation age tracking (<a href="https://github.com/pererikbergman/noupling/issues/131">#131</a>)</h3>
+      <p>Compare current violations against historical snapshots. Classify as new (regressions), recent (2&ndash;4 snapshots), or chronic (5+). Helps prioritize urgent fixes vs accepted debt.</p>
+
+      <h3><span class="tag tag-feat">feat</span> <code>--format all</code> (<a href="https://github.com/pererikbergman/noupling/issues/140">#140</a>)</h3>
+      <p>Generate every report format in a single command: <code>noupling report . --format all</code>. Useful for CI pipelines that publish multiple artifacts.</p>
+
+      <h3>Also in this release:</h3>
+      <ul>
+        <li><span class="tag tag-docs">docs</span> SVG logo replaces text wordmark on the docs site (<a href="https://github.com/pererikbergman/noupling/issues/144">#144</a>)</li>
+      </ul>
+    </article>
 
     <!-- ── v0.4.1 ─────────────────────────────────────── -->
     <article class="release">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -17,7 +17,7 @@
       <li><a href="docs.html" class="active">Docs</a></li>
       <li><a href="changelog.html">Changelog</a></li>
       <li><a href="https://github.com/pererikbergman/noupling">GitHub</a></li>
-      <li><span class="badge">v0.4.1</span></li>
+      <li><span class="badge">v0.5.0</span></li>
     </ul>
   </div>
 </nav>
@@ -53,6 +53,14 @@
       <a href="#diff-mode">Diff Mode</a>
       <a href="#ci-integration">CI Integration</a>
       <a href="#report-formats">Report Formats</a>
+
+      <h4>Tech Lead Metrics</h4>
+      <a href="#independence">Module Independence</a>
+      <a href="#blast-radius">Blast Radius</a>
+      <a href="#instability">Instability (Martin's I)</a>
+      <a href="#dependency-depth">Dependency Depth</a>
+      <a href="#violation-age">Violation Age</a>
+      <a href="#dashboard">Dashboard</a>
 
       <h4>Concepts</h4>
       <a href="#coupling">Coupling Violations</a>
@@ -140,7 +148,7 @@ noupling audit . --fail-below 80</code></pre>
       <h2 id="cmd-report">report</h2>
       <p>Generate a report file from the latest snapshot.</p>
 <pre><code class="language-bash">noupling report [PATH] --format &lt;FORMAT&gt; [--module NAME]</code></pre>
-      <p>Formats: <code>json</code>, <code>xml</code>, <code>md</code>, <code>html</code>, <code>sonar</code>, <code>mermaid</code>, <code>dot</code>, <code>bundle</code>. See <a href="#report-formats">Report Formats</a>.</p>
+      <p>Formats: <code>json</code>, <code>xml</code>, <code>md</code>, <code>html</code>, <code>sonar</code>, <code>mermaid</code>, <code>dot</code>, <code>bundle</code>, <code>dashboard</code>, <code>all</code>. See <a href="#report-formats">Report Formats</a>.</p>
 
 
       <h2 id="cmd-trend">trend</h2>
@@ -304,8 +312,64 @@ noupling audit .</code></pre>
           <tr><td><code>mermaid</code></td><td><code>.noupling/report.mermaid</code></td><td>Embed in Markdown, quick overview</td></tr>
           <tr><td><code>dot</code></td><td><code>.noupling/report.dot</code></td><td>GraphViz rendering, custom pipelines</td></tr>
           <tr><td><code>bundle</code></td><td><code>.noupling/bundle.html</code></td><td>Zoomable sunburst with dependency edges</td></tr>
+          <tr><td><code>dashboard</code></td><td><code>.noupling/dashboard.html</code></td><td>Executive dashboard with all metrics, scorecard, risk matrix</td></tr>
+          <tr><td><code>all</code></td><td><em>all of the above</em></td><td>One command to generate every report format</td></tr>
         </tbody>
       </table>
+
+
+      <!-- Tech Lead Metrics -->
+      <h2 id="independence">Module Independence</h2>
+      <p>For each top-level directory, the ratio of internal dependencies to total dependencies.</p>
+<pre><code>independence = internal_deps / (internal_deps + external_deps)</code></pre>
+      <p>A module with independence <strong>0.95</strong> can be extracted into its own repo. One with <strong>0.40</strong> is deeply entangled. Modules below 70% are flagged in audit output.</p>
+      <div class="callout"><strong>Pro-Tip:</strong> Use this to answer "Can team X own this module independently?" High independence = ready to extract. Low independence = needs decoupling first.</div>
+
+
+      <h2 id="blast-radius">Blast Radius</h2>
+      <p>For each module, the count of other modules transitively affected if it changes. Computed via BFS on the reverse dependency graph.</p>
+      <p>If A imports B and B imports C, then C's blast radius is 2 (changing C affects both B and A). The top 10 highest blast radius modules are shown in audit output.</p>
+      <p>Use this before approving refactoring plans: low blast radius = safe to change, high = ripples through the codebase.</p>
+
+
+      <h2 id="instability">Instability (Martin's I)</h2>
+      <p>Robert C. Martin's metric:</p>
+<pre><code>I = fan_out / (fan_in + fan_out)</code></pre>
+      <ul>
+        <li><strong>I = 0.0</strong>: Maximally stable. Many depend on it; it depends on nothing. Should be abstract.</li>
+        <li><strong>I = 1.0</strong>: Maximally unstable. Depends on many; nothing depends on it. Should be concrete.</li>
+      </ul>
+      <p>The <strong>Zone of Pain</strong>: stable (I &lt; 0.3) modules with high fan-in (&ge; 5) are foundational but hard to change with wide impact. These are flagged separately.</p>
+
+
+      <h2 id="dependency-depth">Dependency Depth</h2>
+      <p>The longest transitive dependency chain in the project, computed via topological sort on the dependency DAG.</p>
+      <p>Deep chains mean changes at the bottom ripple through many layers. Shallow chains mean the architecture is flat and manageable. The audit output shows the maximum depth and the critical path (the actual chain of files).</p>
+
+
+      <h2 id="violation-age">Violation Age</h2>
+      <p>Violations are classified by how long they have existed across snapshots:</p>
+      <ul>
+        <li><strong>New</strong>: first appearance in the latest snapshot &mdash; urgent regressions</li>
+        <li><strong>Recent</strong>: 2&ndash;4 snapshots &mdash; recent debt</li>
+        <li><strong>Chronic</strong>: 5+ snapshots &mdash; accepted long-term debt</li>
+      </ul>
+      <p>This helps prioritize: new regressions need immediate attention; chronic debt gets planned work.</p>
+
+
+      <h2 id="dashboard">Technical Leader Dashboard</h2>
+      <p>An executive single-page HTML report combining all metrics:</p>
+<pre><code class="language-bash">noupling report . --format dashboard</code></pre>
+      <ul>
+        <li><strong>Score badge</strong> with project-level health</li>
+        <li><strong>Metric cards</strong>: Health Score, Total XS, Lowest Independence, Highest Blast Radius</li>
+        <li><strong>Sortable scorecard table</strong>: per-module score, files, violations, circular, XS, independence, instability</li>
+        <li><strong>Risk matrix</strong>: Instability vs Blast Radius scatter plot, color-coded</li>
+        <li><strong>Architecture map</strong>: zoomable sunburst with dependency edges (gray) and violations (red)</li>
+        <li><strong>Violation charts</strong>: by age, by type, plus quick-win refactoring targets</li>
+        <li><strong>Dependency depth</strong> with critical path</li>
+      </ul>
+      <p>Built for presenting to CTOs and tech leads. Self-contained HTML, dark or light theme, print-friendly.</p>
 
 
       <!-- Concepts -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,7 +17,7 @@
       <li><a href="docs.html">Docs</a></li>
       <li><a href="changelog.html">Changelog</a></li>
       <li><a href="https://github.com/pererikbergman/noupling">GitHub</a></li>
-      <li><span class="badge">v0.4.1</span></li>
+      <li><span class="badge">v0.5.0</span></li>
     </ul>
   </div>
 </nav>
@@ -82,8 +82,8 @@
         </article>
         <article class="feature-card">
           <span class="icon">&#128230;</span>
-          <h3>8 report formats</h3>
-          <p>JSON, XML, Markdown, interactive HTML, SonarCloud, Mermaid, GraphViz DOT, and zoomable Sunburst. Integrate with any CI system or documentation pipeline.</p>
+          <h3>9 report formats</h3>
+          <p>JSON, XML, Markdown, interactive HTML, SonarCloud, Mermaid, GraphViz DOT, zoomable Sunburst, and an executive Dashboard. Use <code>--format all</code> to generate every format in one command.</p>
         </article>
       </div>
     </div>


### PR DESCRIPTION
## v0.5.0 — The Tech Lead Release

### New Features
- **Interactive Technical Leader Dashboard** (#132) — single-page HTML dashboard combining all metrics for executive presentation
- **Module independence score** (#126) — internal vs external dependency ratio per module
- **Blast radius metric** (#127) — transitive dependents via reverse graph BFS
- **Instability metric** (#128) — Martin's I with Zone of Pain detection
- **Per-module coupling trend** (#129) — \`--by-module\` flag on trend command
- **Dependency depth & critical path** (#130) — longest transitive chain
- **Violation age tracking** (#131) — new / recent / chronic classification
- **\`--format all\`** (#140) — generate every report format in one command

### Polish
- **SVG logo** (#144) replaces text wordmark on docs site
- Logo color aligned to \`--accent\` for consistency

### Documentation
- README updated with all new features and 9 report formats
- HTML docs site: new "Tech Lead Metrics" section, version badges, expanded report formats table
- Narrative changelog entry for v0.5.0

### Stats
- **9 report formats** (up from 8)
- **185 tests** passing
- **6 new metrics** for technical leaders

🤖 Generated with [Claude Code](https://claude.com/claude-code)