### PR TITLE
feat: actionable coupling mode + SCC-based cycle detection (#143, #158)

### DIFF
--- a/resume.md
+++ b/resume.md
@@ -1,0 +1,1 @@
+claude --resume b3d65e4b-4d71-4ad1-9320-dfaeb0875f6d

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -85,6 +85,8 @@ pub struct AuditResult {
     pub critical_path: Vec<String>,
     /// Violation age summary: new, recent, chronic counts.
     pub violation_age: ViolationAgeSummary,
+    /// Sibling coupling pairs tracked as metrics (not violations) in actionable mode.
+    pub coupling_metrics_count: usize,
     /// Number of imports suppressed by `noupling:ignore` comments.
     pub suppressed_count: usize,
 }
@@ -242,6 +244,32 @@ impl AuditResult {
         self.violations
             .retain(|v| v.is_circular || v.severity >= minimum_severity);
         self.recalculate_score();
+    }
+
+    /// In "actionable" coupling mode, sibling coupling violations are not
+    /// counted as violations — only circular dependencies remain in the
+    /// `violations` list. Layer/rule/cross-module violations are tracked
+    /// separately and unaffected.
+    ///
+    /// Sibling coupling is still measured (cohesion, hotspots, weights) but
+    /// no longer treated as a violation that drags down the score.
+    pub fn apply_coupling_mode(&mut self, mode: &str) {
+        if mode == "actionable" {
+            self.coupling_metrics_count = self.violations.iter().filter(|v| !v.is_circular).count();
+            self.violations.retain(|v| v.is_circular);
+            self.total_xs = self
+                .violations
+                .iter()
+                .map(|v| {
+                    if v.is_circular {
+                        v.break_cost
+                    } else {
+                        v.weight
+                    }
+                })
+                .sum();
+            self.recalculate_score();
+        }
     }
 
     pub fn recalculate_score(&mut self) {
@@ -615,6 +643,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
     }
@@ -1097,6 +1126,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         max_depth,
         critical_path,
         violation_age: ViolationAgeSummary::default(),
+        coupling_metrics_count: 0,
         suppressed_count: 0,
     }
 }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -520,111 +520,155 @@ fn detect_sibling_cycles(
         targets.dedup();
     }
 
-    // Find all elementary cycles using DFS from each node
-    let mut cycles: Vec<DetectedCycle> = Vec::new();
-    let mut seen_keys: FxHashSet<String> = FxHashSet::default();
+    // Find SCCs (Strongly Connected Components) via Tarjan's algorithm.
+    // Each SCC with size >= 2 represents one circular dependency.
+    // This is O(V+E) and avoids the combinatorial blowup of enumerating
+    // all elementary cycles.
+    let sccs = find_sccs(&adj, siblings.len());
 
-    for start in 0..siblings.len() {
-        let mut path = vec![start];
+    let mut cycles: Vec<DetectedCycle> = Vec::new();
+    for scc in sccs {
+        if scc.len() < 2 {
+            continue;
+        }
+        // Build a representative cycle path through the SCC.
+        // Walk the nodes in order, finding edges that exist in adj.
+        let scc_set: FxHashSet<usize> = scc.iter().copied().collect();
+        let mut ordered: Vec<usize> = Vec::new();
         let mut visited_in_path: FxHashSet<usize> = FxHashSet::default();
+
+        // Try to construct a Hamiltonian-like cycle: start at first node,
+        // greedily pick neighbors within the SCC.
+        let start = scc[0];
+        ordered.push(start);
         visited_in_path.insert(start);
-        find_all_cycles_from(
-            start,
-            start,
-            &adj,
-            &mut path,
-            &mut visited_in_path,
-            &mut cycles,
-            &mut seen_keys,
-            siblings,
-            &edge_files,
-            &edge_import_count,
-        );
+        let mut current = start;
+        loop {
+            let next = adj.get(&current).and_then(|neighbors| {
+                neighbors
+                    .iter()
+                    .find(|&&n| scc_set.contains(&n) && !visited_in_path.contains(&n))
+                    .copied()
+            });
+            match next {
+                Some(n) => {
+                    ordered.push(n);
+                    visited_in_path.insert(n);
+                    current = n;
+                }
+                None => break,
+            }
+        }
+        // Add any remaining SCC nodes that weren't reached (rare)
+        for &n in &scc {
+            if !visited_in_path.contains(&n) {
+                ordered.push(n);
+            }
+        }
+
+        // Build dir_path with the cycle closed by repeating the start
+        let mut dir_path: Vec<String> = ordered.iter().map(|&i| siblings[i].clone()).collect();
+        dir_path.push(siblings[start].clone());
+
+        // Build hop_files and hop_import_counts using adj
+        let mut hop_files = Vec::new();
+        let mut hop_import_counts = Vec::new();
+        for w in 0..ordered.len() {
+            let from_idx = ordered[w];
+            let to_idx = if w + 1 < ordered.len() {
+                ordered[w + 1]
+            } else {
+                start
+            };
+            let files = edge_files
+                .get(&(from_idx, to_idx))
+                .cloned()
+                .unwrap_or_default();
+            hop_files.push(files);
+            let count = edge_import_count
+                .get(&(from_idx, to_idx))
+                .copied()
+                .unwrap_or(1);
+            hop_import_counts.push(count);
+        }
+
+        cycles.push(DetectedCycle {
+            dir_path,
+            hop_files,
+            hop_import_counts,
+        });
     }
 
     cycles
 }
 
-#[allow(clippy::too_many_arguments)]
-fn find_all_cycles_from(
-    start: usize,
-    current: usize,
-    adj: &FxHashMap<usize, Vec<usize>>,
-    path: &mut Vec<usize>,
-    visited: &mut FxHashSet<usize>,
-    cycles: &mut Vec<DetectedCycle>,
-    seen_keys: &mut FxHashSet<String>,
-    siblings: &[String],
-    edge_files: &FxHashMap<(usize, usize), (String, String, i32)>,
-    edge_import_count: &FxHashMap<(usize, usize), usize>,
-) {
-    if let Some(neighbors) = adj.get(&current) {
-        for &next in neighbors {
-            if next == start && path.len() >= 2 {
-                // Found a cycle back to start
-                let mut sorted = path.clone();
-                sorted.sort();
-                let key = sorted
-                    .iter()
-                    .map(|i| i.to_string())
-                    .collect::<Vec<_>>()
-                    .join(",");
-                if !seen_keys.contains(&key) {
-                    seen_keys.insert(key);
+/// Tarjan's strongly connected components algorithm (iterative).
+fn find_sccs(adj: &FxHashMap<usize, Vec<usize>>, n: usize) -> Vec<Vec<usize>> {
+    let mut index_counter: i32 = 0;
+    let mut indices: Vec<i32> = vec![-1; n];
+    let mut lowlinks: Vec<i32> = vec![-1; n];
+    let mut on_stack: Vec<bool> = vec![false; n];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut sccs: Vec<Vec<usize>> = Vec::new();
 
-                    let mut dir_path: Vec<String> =
-                        path.iter().map(|&i| siblings[i].clone()).collect();
-                    dir_path.push(siblings[start].clone());
+    let empty: Vec<usize> = Vec::new();
 
-                    let mut hop_files = Vec::new();
-                    let mut hop_import_counts = Vec::new();
-                    for w in 0..path.len() {
-                        let from_idx = path[w];
-                        let to_idx = if w + 1 < path.len() {
-                            path[w + 1]
-                        } else {
-                            start
-                        };
-                        let files = edge_files
-                            .get(&(from_idx, to_idx))
-                            .cloned()
-                            .unwrap_or_default();
-                        hop_files.push(files);
-                        let count = edge_import_count
-                            .get(&(from_idx, to_idx))
-                            .copied()
-                            .unwrap_or(1);
-                        hop_import_counts.push(count);
-                    }
+    for v in 0..n {
+        if indices[v] != -1 {
+            continue;
+        }
+        // Iterative strongconnect
+        let mut work_stack: Vec<(usize, usize)> = vec![(v, 0)];
+        indices[v] = index_counter;
+        lowlinks[v] = index_counter;
+        index_counter += 1;
+        stack.push(v);
+        on_stack[v] = true;
 
-                    cycles.push(DetectedCycle {
-                        dir_path,
-                        hop_files,
-                        hop_import_counts,
-                    });
+        while let Some(&(node, neighbor_idx)) = work_stack.last() {
+            let neighbors = adj.get(&node).unwrap_or(&empty);
+            if neighbor_idx < neighbors.len() {
+                let w = neighbors[neighbor_idx];
+                // Advance pointer
+                if let Some(top) = work_stack.last_mut() {
+                    top.1 += 1;
                 }
-            } else if !visited.contains(&next) && next > start {
-                // Only explore nodes with index > start to avoid finding the same cycle
-                // from different starting points
-                visited.insert(next);
-                path.push(next);
-                find_all_cycles_from(
-                    start,
-                    next,
-                    adj,
-                    path,
-                    visited,
-                    cycles,
-                    seen_keys,
-                    siblings,
-                    edge_files,
-                    edge_import_count,
-                );
-                path.pop();
-                visited.remove(&next);
+
+                if indices[w] == -1 {
+                    indices[w] = index_counter;
+                    lowlinks[w] = index_counter;
+                    index_counter += 1;
+                    stack.push(w);
+                    on_stack[w] = true;
+                    work_stack.push((w, 0));
+                } else if on_stack[w] {
+                    lowlinks[node] = lowlinks[node].min(indices[w]);
+                }
+            } else {
+                // All neighbors processed
+                work_stack.pop();
+                if lowlinks[node] == indices[node] {
+                    // Root of SCC — pop everything until node
+                    let mut scc = Vec::new();
+                    loop {
+                        let w = stack.pop().expect("stack should not be empty");
+                        on_stack[w] = false;
+                        scc.push(w);
+                        if w == node {
+                            break;
+                        }
+                    }
+                    sccs.push(scc);
+                }
+                // Propagate lowlink to parent
+                if let Some(&(parent, _)) = work_stack.last() {
+                    lowlinks[parent] = lowlinks[parent].min(lowlinks[node]);
+                }
             }
         }
     }
+
+    sccs
 }
 
 /// Run the full audit: D_acc aggregation, BFS coupling detection, severity, and health score.

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -964,7 +964,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
             }
         })
         .collect();
-    hotspots.sort_by(|a, b| b.fan_in.cmp(&a.fan_in));
+    hotspots.sort_by_key(|h| std::cmp::Reverse(h.fan_in));
 
     // Compute per-directory cohesion
     let mut dir_files: FxHashMap<String, Vec<&str>> = FxHashMap::default();

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -156,6 +156,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -177,6 +178,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
@@ -203,6 +205,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
@@ -224,6 +227,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
@@ -251,6 +255,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
@@ -269,6 +274,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -162,6 +162,7 @@ fn run_trend(path: &str, last: usize, by_module: bool) -> anyhow::Result<()> {
 
         let mut result = analyzer::audit(&modules, &dependencies);
         result.filter_by_severity(project_settings.thresholds.minimum_severity);
+        result.apply_coupling_mode(&project_settings.thresholds.coupling_mode);
         result.filter_by_layers(&project_settings.layers);
 
         let delta = match prev_score {
@@ -224,6 +225,7 @@ fn run_trend_by_module(
 
         let mut result = analyzer::audit(&modules, &dependencies);
         result.filter_by_severity(settings.thresholds.minimum_severity);
+        result.apply_coupling_mode(&settings.thresholds.coupling_mode);
         result.filter_by_layers(&settings.layers);
 
         let mut dir_severity: BTreeMap<String, f64> = BTreeMap::new();
@@ -432,6 +434,7 @@ fn run_baseline(action: &str, path: &str) -> anyhow::Result<()> {
             let project_settings = settings::Settings::load(Path::new(path))?;
             let mut result = analyzer::audit(&modules, &dependencies);
             result.filter_by_severity(project_settings.thresholds.minimum_severity);
+            result.apply_coupling_mode(&project_settings.thresholds.coupling_mode);
             result.filter_by_layers(&project_settings.layers);
 
             baseline::save_baseline(Path::new(path), &result)?;
@@ -522,6 +525,7 @@ fn run_audit(
     // Single-project mode (existing behavior)
     let mut result = analyzer::audit(&modules, &dependencies);
     result.filter_by_severity(project_settings.thresholds.minimum_severity);
+    result.apply_coupling_mode(&project_settings.thresholds.coupling_mode);
     result.filter_by_layers(&project_settings.layers);
     result.rule_violations = analyzer::check_dependency_rules(
         &modules,
@@ -636,6 +640,7 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
 
     let mut result = analyzer::audit(&report_modules, &report_deps);
     result.filter_by_severity(project_settings.thresholds.minimum_severity);
+    result.apply_coupling_mode(&project_settings.thresholds.coupling_mode);
     result.filter_by_layers(&project_settings.layers);
     result.rule_violations = analyzer::check_dependency_rules(
         &report_modules,

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -259,6 +259,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -289,6 +290,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -316,6 +318,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -807,6 +807,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -833,6 +834,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -865,6 +867,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -913,6 +916,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1032,6 +1032,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1063,6 +1064,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1091,6 +1093,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1113,6 +1116,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1137,6 +1141,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1161,6 +1166,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1193,6 +1199,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 
@@ -1217,6 +1224,7 @@ mod tests {
             max_depth: 0,
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
             suppressed_count: 0,
         };
 

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -703,7 +703,7 @@ pub fn format_text(result: &AuditResult) -> String {
         .iter()
         .filter(|h| h.blast_radius > 0)
         .collect();
-    by_blast.sort_by(|a, b| b.blast_radius.cmp(&a.blast_radius));
+    by_blast.sort_by_key(|h| std::cmp::Reverse(h.blast_radius));
     let top_blast: Vec<_> = by_blast.into_iter().take(10).collect();
     if !top_blast.is_empty() {
         output.push_str("\nHighest Blast Radius:\n");

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -89,6 +89,12 @@ pub struct Thresholds {
     /// Directories with cohesion below this are flagged as low cohesion.
     #[serde(default = "default_min_cohesion")]
     pub min_cohesion: f64,
+    /// Coupling detection mode: "actionable" (default) or "strict".
+    /// - actionable: only flag circular deps, layer/rule/cross-module violations.
+    ///   Sibling coupling is tracked as a metric but not a violation.
+    /// - strict: every sibling dependency is a coupling violation (legacy behavior).
+    #[serde(default = "default_coupling_mode")]
+    pub coupling_mode: String,
 }
 
 fn default_thresholds() -> Thresholds {
@@ -99,7 +105,12 @@ fn default_thresholds() -> Thresholds {
         minimum_severity: default_minimum_severity(),
         hotspot_fan_in: default_hotspot_fan_in(),
         min_cohesion: default_min_cohesion(),
+        coupling_mode: default_coupling_mode(),
     }
+}
+
+fn default_coupling_mode() -> String {
+    "actionable".to_string()
 }
 
 fn default_score_green() -> f64 {


### PR DESCRIPTION
## Summary

Two fundamental fixes to make noupling reports usable on real projects.

### Part 1: Actionable coupling mode (#143)

By default, sibling-to-sibling coupling is no longer a violation. Only flag what genuinely needs action:
- Circular dependencies
- Layer violations
- Custom dependency rule violations
- Cross-module violations (in monorepo mode)

Add \`coupling_mode\` setting: \`actionable\` (new default) or \`strict\` (legacy).

### Part 2: SCC-based cycle detection (#158)

Previous algorithm enumerated all elementary cycles between siblings via DFS from each node. With dense interconnections this exploded combinatorially.

Replace with Tarjan's Strongly Connected Components algorithm:
- O(V+E) instead of exponential
- Each SCC of size >= 2 = one cycle entry
- A tangle of N modules reported once, not N! times

## Real-world impact

Tested on a 1,169-module Android project:

| Metric | Before | After |
|---|---|---|
| Violations | 128,723 | **5** |
| Score | 0.0 | **95.0** |
| JSON report size | 616 MB | (much smaller) |

## Test plan
- [x] 185 tests pass
- [x] clippy clean
- [x] fmt clean
- [x] Tested on noupling itself: 0 violations, 100/100
- [x] Tested on real Android project: 5 cycles, 95/100

Closes #143
Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)