### PR TITLE
feat: add --format pr for code review reports (#152)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,7 +161,7 @@ pub enum Commands {
         #[arg(default_value = ".")]
         path: String,
 
-        /// Output format: json, xml, md, html, sonar, mermaid, dot, bundle, dashboard, or all.
+        /// Output format: json, xml, md, html, sonar, mermaid, dot, bundle, dashboard, pr, or all.
         ///
         /// json      - Comprehensive JSON with directory tree, grouped cycles, and coupling details.
         /// xml       - Same structure as JSON but in XML format.
@@ -172,6 +172,7 @@ pub enum Commands {
         /// dot       - GraphViz DOT graph for custom rendering.
         /// bundle    - Zoomable sunburst with dependency edges (D3.js).
         /// dashboard - Interactive technical leader dashboard (D3.js).
+        /// pr        - Tight Markdown summary for posting as a PR comment.
         /// all       - Generate every format above into .noupling/ in one command.
         #[arg(long)]
         format: String,

--- a/src/main.rs
+++ b/src/main.rs
@@ -727,6 +727,28 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
             reporter::generate_dashboard(&report_modules, &report_deps, &result, &file_path)?;
             println!("Report saved to {}", file_path.display());
         }
+        "pr" => {
+            // Compute deltas from previous snapshot if available
+            let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
+            let all = snap_repo.get_all()?;
+            let prev = all.iter().rfind(|s| s.id != snapshot.id).cloned();
+            let (prev_score, prev_count) = if let Some(prev_snap) = prev {
+                let prev_modules = module_repo.get_by_snapshot(&prev_snap.id)?;
+                let prev_deps = dep_repo.get_by_snapshot(&prev_snap.id)?;
+                let mut prev_result = analyzer::audit(&prev_modules, &prev_deps);
+                prev_result.filter_by_severity(project_settings.thresholds.minimum_severity);
+                prev_result.apply_coupling_mode(&project_settings.thresholds.coupling_mode);
+                prev_result.filter_by_layers(&project_settings.layers);
+                (Some(prev_result.score), Some(prev_result.violations.len()))
+            } else {
+                (None, None)
+            };
+
+            let content = reporter::format_pr(&result, prev_score, prev_count, None, None);
+            let file_path = report_dir.join("pr.md");
+            std::fs::write(&file_path, &content)?;
+            println!("Report saved to {}", file_path.display());
+        }
         "all" => {
             let formats = [
                 "json",
@@ -738,6 +760,7 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
                 "dot",
                 "bundle",
                 "dashboard",
+                "pr",
             ];
             let mut succeeded = 0;
             let mut failed = 0;
@@ -771,7 +794,7 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
         }
         _ => {
             anyhow::bail!(
-                "Unknown format: {}. Use 'json', 'xml', 'md', 'html', 'sonar', 'mermaid', 'dot', 'bundle', 'dashboard', or 'all'.",
+                "Unknown format: {}. Use 'json', 'xml', 'md', 'html', 'sonar', 'mermaid', 'dot', 'bundle', 'dashboard', 'pr', or 'all'.",
                 format
             );
         }
@@ -840,6 +863,13 @@ fn generate_single_format(
         "dashboard" => {
             let file_path = report_dir.join("dashboard.html");
             reporter::generate_dashboard(modules, deps, result, &file_path)?;
+            println!("Report saved to {}", file_path.display());
+        }
+        "pr" => {
+            // Without snapshot history context, generate a simple current-state PR report.
+            let content = reporter::format_pr(result, None, None, None, None);
+            let file_path = report_dir.join("pr.md");
+            std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());
         }
         _ => anyhow::bail!("unknown format"),

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -838,6 +838,105 @@ pub fn format_text(result: &AuditResult) -> String {
     output
 }
 
+/// PR/code-review report: tight Markdown summary suitable for posting as
+/// a PR comment. Length-bounded regardless of project size.
+///
+/// `previous_score` and `previous_violation_count` come from the previous
+/// snapshot (or baseline), and are used to compute deltas. Both are
+/// optional — when absent, only current state is shown.
+pub fn format_pr(
+    result: &AuditResult,
+    previous_score: Option<f64>,
+    previous_violation_count: Option<usize>,
+    new_violations: Option<usize>,
+    resolved_violations: Option<usize>,
+) -> String {
+    let mut out = String::new();
+
+    let score_emoji = if result.score >= 90.0 {
+        "\u{2705}"
+    } else if result.score >= 70.0 {
+        "\u{26a0}\u{fe0f}"
+    } else {
+        "\u{274c}"
+    };
+
+    out.push_str("## Architecture Check\n\n");
+
+    // Score line with optional delta
+    let score_line = match previous_score {
+        Some(prev) => {
+            let delta = result.score - prev;
+            let arrow = if delta > 0.05 {
+                format!(" (+{:.1} since previous)", delta)
+            } else if delta < -0.05 {
+                format!(" ({:.1} since previous)", delta)
+            } else {
+                String::new()
+            };
+            format!(
+                "**Score:** {:.1}/100{} {}\n",
+                result.score, arrow, score_emoji
+            )
+        }
+        None => format!("**Score:** {:.1}/100 {}\n", result.score, score_emoji),
+    };
+    out.push_str(&score_line);
+    out.push('\n');
+
+    // Summary table
+    out.push_str("### Summary\n\n");
+    out.push_str("| Metric | Value |\n");
+    out.push_str("| :--- | :--- |\n");
+    out.push_str(&format!(
+        "| Violations | {}{} |\n",
+        result.violations.len(),
+        previous_violation_count
+            .map(|p| {
+                let d = result.violations.len() as i64 - p as i64;
+                if d > 0 {
+                    format!(" (+{})", d)
+                } else if d < 0 {
+                    format!(" ({})", d)
+                } else {
+                    String::new()
+                }
+            })
+            .unwrap_or_default()
+    ));
+    out.push_str(&format!("| Total XS | {} imports |\n", result.total_xs));
+    if let Some(n) = new_violations {
+        out.push_str(&format!("| New violations | {} |\n", n));
+    }
+    if let Some(r) = resolved_violations {
+        out.push_str(&format!("| Resolved violations | {} |\n", r));
+    }
+    out.push('\n');
+
+    // Top actions
+    let actions = crate::analyzer::compute_top_actions(result, 3);
+    if !actions.is_empty() {
+        out.push_str("### Action items\n\n");
+        for (i, a) in actions.iter().enumerate() {
+            out.push_str(&format!(
+                "{}. **{}** [{}]\n   - {}\n   - {} _(cost: {} import{})_\n\n",
+                i + 1,
+                a.title,
+                a.category,
+                a.detail,
+                a.action,
+                a.cost,
+                if a.cost == 1 { "" } else { "s" }
+            ));
+        }
+    } else {
+        out.push_str("### Action items\n\nNo violations to fix \u{1f389}\n\n");
+    }
+
+    out.push_str(&format!("---\n_{}_\n", VERSION));
+    out
+}
+
 pub fn format_monorepo_text(monorepo: &crate::analyzer::MonorepoResult) -> String {
     let mut output = String::new();
 


### PR DESCRIPTION
## Summary

Tight Markdown summary suitable for posting as a PR comment. Length-bounded regardless of project size.

## Example output

\`\`\`markdown
## Architecture Check

**Score:** 95.0/100 (+2.3 since previous) ✅

### Summary

| Metric | Value |
| :--- | :--- |
| Violations | 5 (-2) |
| Total XS | 5 imports |

### Action items

1. **Break circular dependency in workmanager** [circular]
   - workmanager → utils → presentation → ui → data → domain → workmanager
   - Break the cycle at the weakest link: utils -> workmanager (1 import) _(cost: 1 import)_

2. **Break circular dependency in loyalty** [circular]
   - loyalty → mpass → models → dao → repository → config → loyalty
   - Break the cycle at the weakest link: config -> repository (1 import) _(cost: 1 import)_
\`\`\`

## Features

- Score with delta vs previous snapshot (✅/⚠️/❌ emoji)
- Summary table: violations (with delta), Total XS, optional new/resolved
- Top 3 action items via \`compute_top_actions\`
- Auto-detects previous snapshot from history for delta

## Usage

\`\`\`bash
noupling report . --format pr
\`\`\`

Output saved to \`.noupling/pr.md\`. Ready to paste into a PR comment.

## Test plan

- [x] cargo check, cargo clippy, cargo fmt all pass
- [x] Builds and runs

Note: 5 sandbox-related test failures (filesystem access in /tmp) are unrelated to this change.

Closes #152

🤖 Generated with [Claude Code](https://claude.com/claude-code)