### PR TITLE
feat: add --format strategy for executive trend reports (#154)

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -161,7 +161,7 @@ pub enum Commands {
         #[arg(default_value = ".")]
         path: String,
 
-        /// Output format: json, xml, md, html, sonar, mermaid, dot, bundle, dashboard, pr, briefing, or all.
+        /// Output format: json, xml, md, html, sonar, mermaid, dot, bundle, dashboard, pr, briefing, strategy, or all.
         ///
         /// json      - Comprehensive JSON with directory tree, grouped cycles, and coupling details.
         /// xml       - Same structure as JSON but in XML format.
@@ -174,6 +174,7 @@ pub enum Commands {
         /// dashboard - Interactive technical leader dashboard (D3.js).
         /// pr        - Tight Markdown summary for posting as a PR comment.
         /// briefing  - Sprint planning Markdown report with top 10 ROI-ranked refactorings.
+        /// strategy  - Multi-snapshot HTML trend report for executive review (use --last N).
         /// all       - Generate every format above into .noupling/ in one command.
         #[arg(long)]
         format: String,
@@ -182,6 +183,10 @@ pub enum Commands {
         /// Module names are defined in .noupling/settings.json under "modules".
         #[arg(long, value_name = "NAME")]
         module: Option<String>,
+
+        /// For trend-based reports (strategy): include the last N snapshots.
+        #[arg(long, default_value = "12")]
+        last: usize,
     },
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -60,7 +60,8 @@ fn main() {
             path,
             format,
             module,
-        } => run_report(&path, &format, module.as_deref()),
+            last,
+        } => run_report(&path, &format, module.as_deref(), last),
     };
 
     if let Err(e) = result {
@@ -594,7 +595,12 @@ fn run_audit(
     Ok(())
 }
 
-fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::Result<()> {
+fn run_report(
+    path: &str,
+    format: &str,
+    module_filter: Option<&str>,
+    last: usize,
+) -> anyhow::Result<()> {
     let db = find_db(path)?;
     let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
 
@@ -755,6 +761,19 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
             std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());
         }
+        "strategy" => {
+            let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
+            let file_path = report_dir.join("strategy.html");
+            reporter::generate_strategy_report(
+                &snap_repo,
+                &module_repo,
+                &dep_repo,
+                &project_settings,
+                last,
+                &file_path,
+            )?;
+            println!("Report saved to {}", file_path.display());
+        }
         "all" => {
             let formats = [
                 "json",
@@ -789,6 +808,26 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
                     }
                 }
             }
+            // Strategy needs snapshot history — handle separately
+            let snap_repo = storage::repository::SnapshotRepository::new(&db.conn);
+            let strategy_path = report_dir.join("strategy.html");
+            match reporter::generate_strategy_report(
+                &snap_repo,
+                &module_repo,
+                &dep_repo,
+                &project_settings,
+                last,
+                &strategy_path,
+            ) {
+                Ok(()) => {
+                    succeeded += 1;
+                    println!("Report saved to {}", strategy_path.display());
+                }
+                Err(e) => {
+                    eprintln!("Warning: failed to generate 'strategy' report: {}", e);
+                    failed += 1;
+                }
+            }
             println!(
                 "\nGenerated {} report(s){}",
                 succeeded,
@@ -801,7 +840,7 @@ fn run_report(path: &str, format: &str, module_filter: Option<&str>) -> anyhow::
         }
         _ => {
             anyhow::bail!(
-                "Unknown format: {}. Use 'json', 'xml', 'md', 'html', 'sonar', 'mermaid', 'dot', 'bundle', 'dashboard', 'pr', 'briefing', or 'all'.",
+                "Unknown format: {}. Use 'json', 'xml', 'md', 'html', 'sonar', 'mermaid', 'dot', 'bundle', 'dashboard', 'pr', 'briefing', 'strategy', or 'all'.",
                 format
             );
         }

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -3,6 +3,7 @@ mod dashboard;
 mod graph;
 mod html;
 mod md;
+mod strategy;
 
 use serde::Serialize;
 use std::collections::BTreeMap;
@@ -15,6 +16,7 @@ pub use dashboard::generate_dashboard;
 pub use graph::{format_dot, format_mermaid};
 pub use html::generate_html_report;
 pub use md::generate_markdown_report;
+pub use strategy::generate_strategy_report;
 
 /// The version string used across all report outputs.
 pub const VERSION: &str = concat!("noupling v", env!("CARGO_PKG_VERSION"));

--- a/src/reporter/strategy.rs
+++ b/src/reporter/strategy.rs
@@ -1,0 +1,346 @@
+//! Executive strategy report: multi-snapshot trends and trajectory.
+
+use crate::analyzer::{audit, AuditResult};
+use crate::core::{Dependency, Module, Snapshot};
+use crate::settings::Settings;
+use crate::storage::repository::{DependencyRepository, ModuleRepository, SnapshotRepository};
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+type SnapshotResult = (String, String, AuditResult, Vec<Module>, Vec<Dependency>);
+
+#[derive(Serialize)]
+pub struct StrategyData {
+    pub snapshots: Vec<SnapshotPoint>,
+    pub modules_trajectory: Vec<ModuleTrajectory>,
+    pub velocity: Velocity,
+    pub risk_concentration: Vec<RiskModule>,
+    pub headline: String,
+    pub current_score: f64,
+}
+
+#[derive(Serialize)]
+pub struct SnapshotPoint {
+    pub id: String,
+    pub timestamp: String,
+    pub score: f64,
+    pub violations: usize,
+    pub total_xs: usize,
+}
+
+#[derive(Serialize)]
+pub struct ModuleTrajectory {
+    pub name: String,
+    /// Score per snapshot (in chronological order).
+    pub scores: Vec<f64>,
+    /// Trend: positive = improving, negative = degrading.
+    pub trend: f64,
+}
+
+#[derive(Serialize)]
+pub struct Velocity {
+    pub violations_resolved_avg: f64,
+    pub violations_introduced_avg: f64,
+    pub net_improvement_rate: f64,
+}
+
+#[derive(Serialize)]
+pub struct RiskModule {
+    pub path: String,
+    pub current_blast_radius: usize,
+    pub previous_blast_radius: Option<usize>,
+    pub direction: String,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn generate_strategy_report(
+    snap_repo: &SnapshotRepository,
+    module_repo: &ModuleRepository,
+    dep_repo: &DependencyRepository,
+    settings: &Settings,
+    last: usize,
+    output_path: &std::path::Path,
+) -> anyhow::Result<()> {
+    let all_snapshots = snap_repo.get_all()?;
+    if all_snapshots.is_empty() {
+        anyhow::bail!("No snapshots found. Run `noupling scan` first.");
+    }
+
+    let snapshots: Vec<&Snapshot> = if all_snapshots.len() > last {
+        all_snapshots[all_snapshots.len() - last..].iter().collect()
+    } else {
+        all_snapshots.iter().collect()
+    };
+
+    // Compute audit per snapshot
+    let mut snapshot_results: Vec<SnapshotResult> = Vec::new();
+    for snap in &snapshots {
+        let modules = module_repo.get_by_snapshot(&snap.id)?;
+        let dependencies = dep_repo.get_by_snapshot(&snap.id)?;
+        let mut result = audit(&modules, &dependencies);
+        result.filter_by_severity(settings.thresholds.minimum_severity);
+        result.apply_coupling_mode(&settings.thresholds.coupling_mode);
+        result.filter_by_layers(&settings.layers);
+        snapshot_results.push((
+            snap.id.clone(),
+            snap.timestamp.clone(),
+            result,
+            modules,
+            dependencies,
+        ));
+    }
+
+    let snapshot_points: Vec<SnapshotPoint> = snapshot_results
+        .iter()
+        .map(|(id, ts, r, _, _)| SnapshotPoint {
+            id: short_id(id),
+            timestamp: ts.clone(),
+            score: r.score,
+            violations: r.violations.len(),
+            total_xs: r.total_xs,
+        })
+        .collect();
+
+    // Module trajectories: per-top-level-directory scores per snapshot
+    let mut module_scores: BTreeMap<String, Vec<f64>> = BTreeMap::new();
+    let snap_count = snapshot_results.len();
+    for (idx, (_, _, result, modules, _)) in snapshot_results.iter().enumerate() {
+        let dir_scores = compute_per_module_scores(modules, result);
+        // Ensure every module that has appeared has an entry (with NaN for missing snapshots)
+        for (dir, score) in &dir_scores {
+            let entry = module_scores
+                .entry(dir.clone())
+                .or_insert_with(|| vec![f64::NAN; snap_count]);
+            entry[idx] = *score;
+        }
+    }
+    // Pad any modules added later
+    for scores in module_scores.values_mut() {
+        if scores.len() < snap_count {
+            scores.resize(snap_count, f64::NAN);
+        }
+    }
+
+    let modules_trajectory: Vec<ModuleTrajectory> = module_scores
+        .into_iter()
+        .map(|(name, scores)| {
+            let trend = compute_trend(&scores);
+            ModuleTrajectory {
+                name,
+                scores,
+                trend,
+            }
+        })
+        .collect();
+
+    // Velocity: how many violations are added vs removed per snapshot
+    let velocity = compute_velocity(&snapshot_results);
+
+    // Risk concentration: top blast-radius modules now vs previous
+    let risk_concentration = compute_risk_concentration(&snapshot_results);
+
+    // Headline
+    let headline = build_headline(&snapshot_points);
+    let current_score = snapshot_points.last().map(|p| p.score).unwrap_or(0.0);
+
+    let data = StrategyData {
+        snapshots: snapshot_points,
+        modules_trajectory,
+        velocity,
+        risk_concentration,
+        headline,
+        current_score,
+    };
+    let json = serde_json::to_string(&data)?;
+
+    let html = format!(
+        include_str!("strategy_template.html"),
+        json = json,
+        version = super::VERSION,
+    );
+
+    if let Some(parent) = output_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(output_path, html)?;
+    Ok(())
+}
+
+fn short_id(id: &str) -> String {
+    if id.len() > 8 {
+        id[..8].to_string()
+    } else {
+        id.to_string()
+    }
+}
+
+fn compute_per_module_scores(modules: &[Module], result: &AuditResult) -> BTreeMap<String, f64> {
+    let mut dir_modules: BTreeMap<String, usize> = BTreeMap::new();
+    for m in modules {
+        if let Some(top) = m.path.split('/').next() {
+            if m.path.contains('/') {
+                *dir_modules.entry(top.to_string()).or_insert(0) += 1;
+            }
+        }
+    }
+
+    let mut dir_severity: BTreeMap<String, f64> = BTreeMap::new();
+    for v in &result.violations {
+        if let Some(top) = v.dir_a.split('/').next() {
+            *dir_severity.entry(top.to_string()).or_insert(0.0) += v.severity;
+        }
+    }
+
+    let mut scores = BTreeMap::new();
+    for (dir, count) in dir_modules {
+        let sev = dir_severity.get(&dir).copied().unwrap_or(0.0);
+        let score = (100.0 * (1.0 - sev / count.max(1) as f64)).clamp(0.0, 100.0);
+        scores.insert(dir, score);
+    }
+    scores
+}
+
+/// Linear regression slope on score series, ignoring NaN values.
+fn compute_trend(scores: &[f64]) -> f64 {
+    let valid: Vec<(f64, f64)> = scores
+        .iter()
+        .enumerate()
+        .filter(|(_, &s)| !s.is_nan())
+        .map(|(i, &s)| (i as f64, s))
+        .collect();
+    if valid.len() < 2 {
+        return 0.0;
+    }
+    let n = valid.len() as f64;
+    let sum_x: f64 = valid.iter().map(|(x, _)| x).sum();
+    let sum_y: f64 = valid.iter().map(|(_, y)| y).sum();
+    let sum_xy: f64 = valid.iter().map(|(x, y)| x * y).sum();
+    let sum_xx: f64 = valid.iter().map(|(x, _)| x * x).sum();
+    let denom = n * sum_xx - sum_x * sum_x;
+    if denom.abs() < f64::EPSILON {
+        0.0
+    } else {
+        (n * sum_xy - sum_x * sum_y) / denom
+    }
+}
+
+fn compute_velocity(snapshot_results: &[SnapshotResult]) -> Velocity {
+    if snapshot_results.len() < 2 {
+        return Velocity {
+            violations_resolved_avg: 0.0,
+            violations_introduced_avg: 0.0,
+            net_improvement_rate: 0.0,
+        };
+    }
+
+    let mut total_resolved = 0i64;
+    let mut total_introduced = 0i64;
+    let mut transitions = 0;
+
+    for window in snapshot_results.windows(2) {
+        let prev_violations: std::collections::HashSet<(String, String)> = window[0]
+            .2
+            .violations
+            .iter()
+            .map(|v| (v.from_module.clone(), v.to_module.clone()))
+            .collect();
+        let curr_violations: std::collections::HashSet<(String, String)> = window[1]
+            .2
+            .violations
+            .iter()
+            .map(|v| (v.from_module.clone(), v.to_module.clone()))
+            .collect();
+
+        let resolved = prev_violations.difference(&curr_violations).count() as i64;
+        let introduced = curr_violations.difference(&prev_violations).count() as i64;
+        total_resolved += resolved;
+        total_introduced += introduced;
+        transitions += 1;
+    }
+
+    let n = transitions.max(1) as f64;
+    Velocity {
+        violations_resolved_avg: total_resolved as f64 / n,
+        violations_introduced_avg: total_introduced as f64 / n,
+        net_improvement_rate: (total_resolved - total_introduced) as f64 / n,
+    }
+}
+
+fn compute_risk_concentration(snapshot_results: &[SnapshotResult]) -> Vec<RiskModule> {
+    let last = match snapshot_results.last() {
+        Some(s) => s,
+        None => return Vec::new(),
+    };
+    let mut top: Vec<&crate::analyzer::ModuleMetrics> = last
+        .2
+        .hotspots
+        .iter()
+        .filter(|h| h.blast_radius > 0)
+        .collect();
+    top.sort_by_key(|h| std::cmp::Reverse(h.blast_radius));
+    let top: Vec<&crate::analyzer::ModuleMetrics> = top.into_iter().take(5).collect();
+
+    let prev_blast: BTreeMap<String, usize> = if snapshot_results.len() >= 2 {
+        let prev = &snapshot_results[snapshot_results.len() - 2];
+        prev.2
+            .hotspots
+            .iter()
+            .map(|h| (h.path.clone(), h.blast_radius))
+            .collect()
+    } else {
+        BTreeMap::new()
+    };
+
+    top.into_iter()
+        .map(|h| {
+            let prev = prev_blast.get(&h.path).copied();
+            let direction = match prev {
+                Some(p) if h.blast_radius > p => "rising".to_string(),
+                Some(p) if h.blast_radius < p => "falling".to_string(),
+                Some(_) => "stable".to_string(),
+                None => "new".to_string(),
+            };
+            RiskModule {
+                path: short_path(&h.path),
+                current_blast_radius: h.blast_radius,
+                previous_blast_radius: prev,
+                direction,
+            }
+        })
+        .collect()
+}
+
+fn short_path(path: &str) -> String {
+    std::path::Path::new(path)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or(path)
+        .to_string()
+}
+
+fn build_headline(points: &[SnapshotPoint]) -> String {
+    if points.len() < 2 {
+        return format!(
+            "Tracking architecture health (current score: {:.1}/100)",
+            points.last().map(|p| p.score).unwrap_or(0.0)
+        );
+    }
+    let first = points.first().unwrap().score;
+    let last = points.last().unwrap().score;
+    let delta = last - first;
+    let trend_word = if delta.abs() < 0.5 {
+        "stable"
+    } else if delta > 0.0 {
+        "improving"
+    } else {
+        "declining"
+    };
+    let n = points.len();
+    format!(
+        "Architecture health is {} ({:+.1} points over the last {} snapshot{})",
+        trend_word,
+        delta,
+        n,
+        if n == 1 { "" } else { "s" }
+    )
+}

--- a/src/reporter/strategy_template.html
+++ b/src/reporter/strategy_template.html
@@ -1,0 +1,225 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>noupling — Architecture Strategy Report</title>
+<style>
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, sans-serif; background: #fff; color: #1e293b; }}
+.header {{ background: #f8fafc; border-bottom: 1px solid #e2e8f0; padding: 1.5rem 2rem; }}
+.header h1 {{ font-size: 1.4rem; font-weight: 700; }}
+.header h1 span {{ color: #3b82f6; }}
+.header .subtitle {{ font-size: 0.85rem; color: #64748b; margin-top: 0.25rem; }}
+.container {{ max-width: 1200px; margin: 0 auto; padding: 2rem; }}
+.headline {{ background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%); border: 1px solid #bae6fd; border-radius: 12px; padding: 1.5rem 2rem; margin-bottom: 2rem; text-align: center; }}
+.headline h2 {{ font-size: 1.2rem; font-weight: 700; color: #0c4a6e; margin-bottom: 0.5rem; }}
+.headline .score {{ font-size: 2.5rem; font-weight: 800; color: #0284c7; }}
+section {{ margin-bottom: 2.5rem; }}
+section h2 {{ font-size: 1.1rem; font-weight: 700; margin-bottom: 1rem; color: #334155; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.5rem; }}
+.chart-box {{ background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1.5rem; }}
+.metric-grid {{ display: grid; grid-template-columns: repeat(3, 1fr); gap: 1rem; margin-bottom: 1.5rem; }}
+.metric-card {{ background: #fff; border: 1px solid #e2e8f0; border-radius: 8px; padding: 1rem 1.25rem; text-align: center; }}
+.metric-card .label {{ font-size: 0.7rem; color: #94a3b8; text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }}
+.metric-card .value {{ font-size: 1.75rem; font-weight: 700; margin-top: 0.25rem; }}
+.metric-card .detail {{ font-size: 0.75rem; color: #64748b; margin-top: 0.15rem; }}
+.green {{ color: #16a34a; }}
+.yellow {{ color: #ca8a04; }}
+.red {{ color: #dc2626; }}
+.blue {{ color: #0284c7; }}
+table {{ width: 100%; border-collapse: collapse; font-size: 0.85rem; }}
+th, td {{ text-align: left; padding: 0.5rem 0.75rem; border-bottom: 1px solid #e2e8f0; }}
+th {{ background: #f8fafc; color: #64748b; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.04em; font-weight: 600; }}
+.heatmap-cell {{ display: inline-block; width: 18px; height: 18px; border-radius: 2px; margin-right: 1px; vertical-align: middle; }}
+.tooltip {{ position: fixed; background: #1e293b; color: #e2e8f0; border-radius: 6px; padding: 0.4rem 0.65rem; font-size: 0.7rem; pointer-events: none; opacity: 0; z-index: 100; }}
+footer {{ text-align: center; font-size: 0.65rem; color: #cbd5e1; padding: 1rem; border-top: 1px solid #e2e8f0; }}
+@media print {{ .header {{ background: #fff; }} section {{ break-inside: avoid; }} }}
+@media (max-width: 768px) {{ .metric-grid {{ grid-template-columns: 1fr; }} }}
+</style>
+</head>
+<body>
+
+<div class="header">
+    <h1><span>nou</span>pling — Architecture Strategy Report</h1>
+    <div class="subtitle">Multi-snapshot trends and trajectory</div>
+</div>
+
+<div class="container">
+
+<!-- Headline -->
+<div class="headline" id="headline"></div>
+
+<!-- Score trajectory -->
+<section>
+    <h2>Score Trajectory</h2>
+    <div class="chart-box">
+        <div id="trajectory-chart"></div>
+    </div>
+</section>
+
+<!-- Velocity -->
+<section>
+    <h2>Velocity</h2>
+    <div class="metric-grid" id="velocity-cards"></div>
+</section>
+
+<!-- Module trajectory matrix -->
+<section>
+    <h2>Module Trajectory Heatmap</h2>
+    <div class="chart-box">
+        <p style="font-size:0.8rem;color:#64748b;margin-bottom:0.75rem">Each row is a top-level module; each column is a snapshot. Cell color = score.</p>
+        <div id="heatmap"></div>
+    </div>
+</section>
+
+<!-- Risk concentration -->
+<section>
+    <h2>Risk Concentration</h2>
+    <div class="chart-box">
+        <p style="font-size:0.8rem;color:#64748b;margin-bottom:0.75rem">Top 5 modules by current blast radius. Direction shows trend vs previous snapshot.</p>
+        <table id="risk-table"></table>
+    </div>
+</section>
+
+</div>
+
+<footer>{version}</footer>
+<div id="tooltip" class="tooltip"></div>
+
+<script src="https://d3js.org/d3.v7.min.js"></script>
+<script>
+const D = {json};
+const tooltip = document.getElementById("tooltip");
+
+// ── Headline ──
+(function() {{
+    const cls = D.current_score >= 90 ? "green" : D.current_score >= 70 ? "yellow" : "red";
+    document.getElementById("headline").innerHTML = `
+        <h2>${{D.headline}}</h2>
+        <div class="score ${{cls}}">${{D.current_score.toFixed(1)}}/100</div>
+        <div style="font-size:0.85rem;color:#0369a1;margin-top:0.5rem">Current architectural health score</div>`;
+}})();
+
+// ── Score trajectory chart ──
+(function() {{
+    if (D.snapshots.length === 0) return;
+    const w = 1100, h = 280, pad = {{ top: 20, right: 30, bottom: 40, left: 50 }};
+    const svg = d3.select("#trajectory-chart").append("svg")
+        .attr("width", "100%").attr("height", h).attr("viewBox", `0 0 ${{w}} ${{h}}`);
+
+    const x = d3.scalePoint().domain(D.snapshots.map(s => s.id)).range([pad.left, w - pad.right]).padding(0.5);
+    const y = d3.scaleLinear().domain([0, 100]).range([h - pad.bottom, pad.top]);
+
+    // Axes
+    svg.append("g").attr("transform", `translate(0,${{h - pad.bottom}})`).call(d3.axisBottom(x)).selectAll("text").style("font-size", "10px");
+    svg.append("g").attr("transform", `translate(${{pad.left}},0)`).call(d3.axisLeft(y).ticks(5)).selectAll("text").style("font-size", "10px");
+
+    // Grid lines
+    [70, 90].forEach(v => {{
+        svg.append("line").attr("x1", pad.left).attr("x2", w - pad.right).attr("y1", y(v)).attr("y2", y(v))
+            .attr("stroke", v === 90 ? "#16a34a" : "#ca8a04").attr("stroke-dasharray", "3,3").attr("stroke-opacity", 0.4);
+    }});
+
+    // Line
+    const line = d3.line().x(d => x(d.id)).y(d => y(d.score)).curve(d3.curveMonotoneX);
+    svg.append("path").datum(D.snapshots).attr("fill", "none").attr("stroke", "#0284c7").attr("stroke-width", 2).attr("d", line);
+
+    // Points
+    svg.selectAll("circle").data(D.snapshots).join("circle")
+        .attr("cx", d => x(d.id)).attr("cy", d => y(d.score)).attr("r", 4).attr("fill", "#0284c7")
+        .on("mouseover", (e, d) => {{
+            tooltip.innerHTML = `<strong>${{d.id}}</strong><br>${{d.timestamp}}<br>Score: ${{d.score.toFixed(1)}}<br>Violations: ${{d.violations}}`;
+            tooltip.style.opacity = 1;
+        }})
+        .on("mousemove", e => {{ tooltip.style.left = (e.clientX + 10) + "px"; tooltip.style.top = (e.clientY - 10) + "px"; }})
+        .on("mouseout", () => {{ tooltip.style.opacity = 0; }});
+
+    // Labels
+    svg.append("text").attr("x", w / 2).attr("y", h - 5).attr("text-anchor", "middle").style("font-size", "10px").style("fill", "#94a3b8").text("Snapshot");
+    svg.append("text").attr("transform", "rotate(-90)").attr("x", -h / 2).attr("y", 12).attr("text-anchor", "middle").style("font-size", "10px").style("fill", "#94a3b8").text("Health Score");
+}})();
+
+// ── Velocity ──
+(function() {{
+    const v = D.velocity;
+    const netSign = v.net_improvement_rate > 0 ? "+" : "";
+    const netCls = v.net_improvement_rate > 0 ? "green" : v.net_improvement_rate < 0 ? "red" : "blue";
+    const html = `
+        <div class="metric-card">
+            <div class="label">Resolved per snapshot</div>
+            <div class="value green">${{v.violations_resolved_avg.toFixed(1)}}</div>
+            <div class="detail">average</div>
+        </div>
+        <div class="metric-card">
+            <div class="label">Introduced per snapshot</div>
+            <div class="value red">${{v.violations_introduced_avg.toFixed(1)}}</div>
+            <div class="detail">average</div>
+        </div>
+        <div class="metric-card">
+            <div class="label">Net improvement rate</div>
+            <div class="value ${{netCls}}">${{netSign}}${{v.net_improvement_rate.toFixed(1)}}</div>
+            <div class="detail">violations / snapshot</div>
+        </div>`;
+    document.getElementById("velocity-cards").innerHTML = html;
+}})();
+
+// ── Module trajectory heatmap ──
+(function() {{
+    if (D.modules_trajectory.length === 0 || D.snapshots.length === 0) {{
+        document.getElementById("heatmap").innerHTML = "<p style='color:#94a3b8'>No module trajectory data.</p>";
+        return;
+    }}
+
+    function colorFor(score) {{
+        if (isNaN(score)) return "#e5e7eb";
+        if (score >= 90) return "#16a34a";
+        if (score >= 70) return "#ca8a04";
+        return "#dc2626";
+    }}
+
+    let html = "<table><thead><tr><th>Module</th>";
+    D.snapshots.forEach(s => html += `<th style="text-align:center;font-size:0.6rem">${{s.id.substring(0, 6)}}</th>`);
+    html += "<th style='text-align:right'>Trend</th></tr></thead><tbody>";
+
+    const sorted = [...D.modules_trajectory].sort((a, b) => a.trend - b.trend);
+    sorted.forEach(m => {{
+        const trendStr = m.trend > 0.1 ? `<span class="green">&#x2191; +${{m.trend.toFixed(2)}}</span>` :
+                         m.trend < -0.1 ? `<span class="red">&#x2193; ${{m.trend.toFixed(2)}}</span>` :
+                         `<span style="color:#94a3b8">stable</span>`;
+        html += `<tr><td><strong>${{m.name}}</strong></td>`;
+        m.scores.forEach((s, i) => {{
+            const title = isNaN(s) ? "no data" : s.toFixed(1);
+            html += `<td style="text-align:center"><span class="heatmap-cell" style="background:${{colorFor(s)}}" title="${{title}}"></span></td>`;
+        }});
+        html += `<td style="text-align:right;font-size:0.8rem">${{trendStr}}</td></tr>`;
+    }});
+    html += "</tbody></table>";
+    document.getElementById("heatmap").innerHTML = html;
+}})();
+
+// ── Risk concentration ──
+(function() {{
+    if (D.risk_concentration.length === 0) {{
+        document.getElementById("risk-table").innerHTML = "<p style='color:#94a3b8'>No risk concentration data.</p>";
+        return;
+    }}
+
+    let html = "<thead><tr><th>Module</th><th>Current Blast Radius</th><th>Previous</th><th>Direction</th></tr></thead><tbody>";
+    D.risk_concentration.forEach(r => {{
+        const dirCls = r.direction === "rising" ? "red" : r.direction === "falling" ? "green" : r.direction === "new" ? "yellow" : "blue";
+        const arrow = r.direction === "rising" ? "&#x2191;" : r.direction === "falling" ? "&#x2193;" : r.direction === "new" ? "&#x2733;" : "=";
+        const prev = r.previous_blast_radius !== null && r.previous_blast_radius !== undefined ? r.previous_blast_radius : "—";
+        html += `<tr>
+            <td><strong>${{r.path}}</strong></td>
+            <td><span class="value" style="font-size:1rem;font-weight:700">${{r.current_blast_radius}}</span></td>
+            <td>${{prev}}</td>
+            <td><span class="${{dirCls}}">${{arrow}} ${{r.direction}}</span></td>
+        </tr>`;
+    }});
+    html += "</tbody>";
+    document.getElementById("risk-table").innerHTML = html;
+}})();
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Multi-snapshot HTML trend report for executive review (CTO, tech leadership, quarterly business reviews).

## Sections

1. **Headline:** \"Architecture health is improving 4.2 points over the last 12 snapshots\"
2. **Score trajectory line chart** with 70/90 threshold lines, hover tooltips
3. **Velocity:** violations resolved per snapshot, introduced per snapshot, net rate
4. **Module trajectory heatmap:** rows = top-level modules, columns = snapshots, color-coded by score, with trend slope per row
5. **Risk concentration:** top 5 modules by current blast radius with direction (rising / falling / stable / new)

## Usage

\`\`\`bash
noupling report . --format strategy --last 12
\`\`\`

\`--last N\` (default 12) controls the snapshot window.

Output saved to \`.noupling/strategy.html\`.

## Implementation notes

- Linear regression slope used for module trend computation
- Velocity computed by diffing violation fingerprints between consecutive snapshots
- Self-contained HTML with D3.js from CDN, print-friendly

## Test plan

- [x] cargo check, cargo clippy, cargo fmt all pass
- [x] Builds and runs

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)