### PR TITLE
feat: HTML report shows all violations + score explainers (#165)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -607,9 +607,101 @@ fn detect_sibling_cycles(
                 }
             }
         }
+
+        // If no mutual pairs were found in this SCC (e.g. A→B→C→A with no
+        // reverse edges), find a directed cycle through the SCC so the user
+        // still sees the violation.
+        if reported.is_empty()
+            || scc.iter().all(|n| {
+                !scc.iter().any(|m| {
+                    n != m && {
+                        let key = if n < m { (*n, *m) } else { (*m, *n) };
+                        reported.contains(&key)
+                    }
+                })
+            })
+        {
+            // Check if we already reported anything for this SCC
+            let scc_covered: bool = scc.iter().any(|n| {
+                scc.iter().any(|m| {
+                    if n >= m {
+                        return false;
+                    }
+                    reported.contains(&(*n, *m))
+                })
+            });
+            if !scc_covered {
+                // DFS from first node to find a cycle within the SCC
+                if let Some(cycle_nodes) = find_cycle_in_scc(&scc_set, &adj, scc[0]) {
+                    let mut dir_path: Vec<String> = cycle_nodes
+                        .iter()
+                        .map(|&idx| siblings[idx].clone())
+                        .collect();
+                    dir_path.push(siblings[cycle_nodes[0]].clone()); // close the loop
+
+                    let mut hop_files_list = Vec::new();
+                    let mut hop_counts = Vec::new();
+                    for w in cycle_nodes.windows(2) {
+                        hop_files_list
+                            .push(edge_files.get(&(w[0], w[1])).cloned().unwrap_or_default());
+                        hop_counts.push(edge_import_count.get(&(w[0], w[1])).copied().unwrap_or(1));
+                    }
+                    // Closing edge
+                    let last = *cycle_nodes.last().unwrap();
+                    let first = cycle_nodes[0];
+                    hop_files_list
+                        .push(edge_files.get(&(last, first)).cloned().unwrap_or_default());
+                    hop_counts
+                        .push(edge_import_count.get(&(last, first)).copied().unwrap_or(1));
+
+                    cycles.push(DetectedCycle {
+                        dir_path,
+                        hop_files: hop_files_list,
+                        hop_import_counts: hop_counts,
+                    });
+                }
+            }
+        }
     }
 
     cycles
+}
+
+/// Find a simple directed cycle within an SCC starting from `start`.
+/// Returns the cycle as a list of node indices (without the closing duplicate).
+fn find_cycle_in_scc(
+    scc_set: &FxHashSet<usize>,
+    adj: &FxHashMap<usize, Vec<usize>>,
+    start: usize,
+) -> Option<Vec<usize>> {
+    let mut visited: FxHashMap<usize, usize> = FxHashMap::default(); // node -> parent
+    let mut stack = vec![(start, 0usize)]; // (node, neighbor_index)
+    visited.insert(start, usize::MAX);
+
+    while let Some((node, ni)) = stack.last_mut() {
+        let node = *node;
+        let neighbors = adj.get(&node);
+        let len = neighbors.map(|n| n.len()).unwrap_or(0);
+        if *ni >= len {
+            stack.pop();
+            continue;
+        }
+        let next = neighbors.unwrap()[*ni];
+        *ni += 1;
+        if !scc_set.contains(&next) {
+            continue;
+        }
+        if next == start {
+            // Found cycle back to start — extract path
+            let path: Vec<usize> = stack.iter().map(|(n, _)| *n).collect();
+            return Some(path);
+        }
+        if !visited.contains_key(&next) {
+            visited.insert(next, node);
+            stack.push((next, 0));
+        }
+    }
+    None
 }
 
 /// Tarjan's strongly connected components algorithm (iterative).

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -651,8 +651,7 @@ fn detect_sibling_cycles(
                     let first = cycle_nodes[0];
                     hop_files_list
                         .push(edge_files.get(&(last, first)).cloned().unwrap_or_default());
-                    hop_counts
-                        .push(edge_import_count.get(&(last, first)).copied().unwrap_or(1));
+                    hop_counts.push(edge_import_count.get(&(last, first)).copied().unwrap_or(1));
 
                     cycles.push(DetectedCycle {
                         dir_path,
@@ -696,8 +695,8 @@ fn find_cycle_in_scc(
             let path: Vec<usize> = stack.iter().map(|(n, _)| *n).collect();
             return Some(path);
         }
-        if !visited.contains_key(&next) {
-            visited.insert(next, node);
+        if let std::collections::hash_map::Entry::Vacant(e) = visited.entry(next) {
+            e.insert(node);
             stack.push((next, 0));
         }
     }

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -87,6 +87,9 @@ pub struct AuditResult {
     pub violation_age: ViolationAgeSummary,
     /// Sibling coupling pairs tracked as metrics (not violations) in actionable mode.
     pub coupling_metrics_count: usize,
+    /// The actual sibling coupling pairs (kept for display in actionable mode,
+    /// where they are informational rather than violations).
+    pub coupling_metrics: Vec<CouplingViolation>,
     /// Number of imports suppressed by `noupling:ignore` comments.
     pub suppressed_count: usize,
 }
@@ -273,8 +276,15 @@ impl AuditResult {
     /// no longer treated as a violation that drags down the score.
     pub fn apply_coupling_mode(&mut self, mode: &str) {
         if mode == "actionable" {
-            self.coupling_metrics_count = self.violations.iter().filter(|v| !v.is_circular).count();
-            self.violations.retain(|v| v.is_circular);
+            // Move non-circular (sibling coupling) entries from violations into
+            // coupling_metrics — they remain available for display but no longer
+            // count as violations or affect the score.
+            let (cycles, coupling): (Vec<_>, Vec<_>) = std::mem::take(&mut self.violations)
+                .into_iter()
+                .partition(|v| v.is_circular);
+            self.violations = cycles;
+            self.coupling_metrics_count = coupling.len();
+            self.coupling_metrics = coupling;
             self.total_xs = self
                 .violations
                 .iter()
@@ -544,77 +554,59 @@ fn detect_sibling_cycles(
     // all elementary cycles.
     let sccs = find_sccs(&adj, siblings.len());
 
+    // For each SCC of size >= 2, enumerate every mutual-dependency pair
+    // (i, j) where both i -> j and j -> i exist. Each pair is reported as
+    // a separate 2-cycle violation. This gives users actionable visibility
+    // into specific module pairs that need decoupling, while still being
+    // bounded (O(edges in SCC) instead of O(elementary cycles)).
     let mut cycles: Vec<DetectedCycle> = Vec::new();
+    let mut reported: FxHashSet<(usize, usize)> = FxHashSet::default();
+
     for scc in sccs {
         if scc.len() < 2 {
             continue;
         }
-        // Build a representative cycle path through the SCC.
-        // Walk the nodes in order, finding edges that exist in adj.
         let scc_set: FxHashSet<usize> = scc.iter().copied().collect();
-        let mut ordered: Vec<usize> = Vec::new();
-        let mut visited_in_path: FxHashSet<usize> = FxHashSet::default();
 
-        // Try to construct a Hamiltonian-like cycle: start at first node,
-        // greedily pick neighbors within the SCC.
-        let start = scc[0];
-        ordered.push(start);
-        visited_in_path.insert(start);
-        let mut current = start;
-        loop {
-            let next = adj.get(&current).and_then(|neighbors| {
-                neighbors
-                    .iter()
-                    .find(|&&n| scc_set.contains(&n) && !visited_in_path.contains(&n))
-                    .copied()
-            });
-            match next {
-                Some(n) => {
-                    ordered.push(n);
-                    visited_in_path.insert(n);
-                    current = n;
+        // Find all mutual pairs within the SCC
+        for &i in &scc {
+            if let Some(neighbors) = adj.get(&i) {
+                for &j in neighbors {
+                    if !scc_set.contains(&j) || i == j {
+                        continue;
+                    }
+                    // Check reverse edge exists
+                    let reverse = adj.get(&j).is_some_and(|nbrs| nbrs.contains(&i));
+                    if !reverse {
+                        continue;
+                    }
+                    // Canonical ordering to dedupe
+                    let key = if i < j { (i, j) } else { (j, i) };
+                    if !reported.insert(key) {
+                        continue;
+                    }
+                    let (a, b) = key;
+                    let dir_path = vec![
+                        siblings[a].clone(),
+                        siblings[b].clone(),
+                        siblings[a].clone(),
+                    ];
+                    let hop_files = vec![
+                        edge_files.get(&(a, b)).cloned().unwrap_or_default(),
+                        edge_files.get(&(b, a)).cloned().unwrap_or_default(),
+                    ];
+                    let hop_import_counts = vec![
+                        edge_import_count.get(&(a, b)).copied().unwrap_or(1),
+                        edge_import_count.get(&(b, a)).copied().unwrap_or(1),
+                    ];
+                    cycles.push(DetectedCycle {
+                        dir_path,
+                        hop_files,
+                        hop_import_counts,
+                    });
                 }
-                None => break,
             }
         }
-        // Add any remaining SCC nodes that weren't reached (rare)
-        for &n in &scc {
-            if !visited_in_path.contains(&n) {
-                ordered.push(n);
-            }
-        }
-
-        // Build dir_path with the cycle closed by repeating the start
-        let mut dir_path: Vec<String> = ordered.iter().map(|&i| siblings[i].clone()).collect();
-        dir_path.push(siblings[start].clone());
-
-        // Build hop_files and hop_import_counts using adj
-        let mut hop_files = Vec::new();
-        let mut hop_import_counts = Vec::new();
-        for w in 0..ordered.len() {
-            let from_idx = ordered[w];
-            let to_idx = if w + 1 < ordered.len() {
-                ordered[w + 1]
-            } else {
-                start
-            };
-            let files = edge_files
-                .get(&(from_idx, to_idx))
-                .cloned()
-                .unwrap_or_default();
-            hop_files.push(files);
-            let count = edge_import_count
-                .get(&(from_idx, to_idx))
-                .copied()
-                .unwrap_or(1);
-            hop_import_counts.push(count);
-        }
-
-        cycles.push(DetectedCycle {
-            dir_path,
-            hop_files,
-            hop_import_counts,
-        });
     }
 
     cycles
@@ -706,6 +698,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
     }
@@ -1189,6 +1182,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         critical_path,
         violation_age: ViolationAgeSummary::default(),
         coupling_metrics_count: 0,
+        coupling_metrics: Vec::new(),
         suppressed_count: 0,
     }
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -157,6 +157,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -179,6 +180,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
@@ -206,6 +208,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
@@ -228,6 +231,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
@@ -256,6 +260,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
@@ -275,6 +280,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();

--- a/src/reporter/bundle.rs
+++ b/src/reporter/bundle.rs
@@ -82,20 +82,28 @@ fn build_data(modules: &[Module], dependencies: &[Dependency], result: &AuditRes
 
     let tree = build_tree(&dir_files);
 
-    // Compute per-directory scores from violations
+    // Compute per-directory scores from violations.
+    // Each module is counted in every ancestor directory, and each violation
+    // is assigned to the common parent of its two directories (matching the
+    // HTML report's logic so colors are meaningful).
     let mut dir_violation_severity: HashMap<String, f64> = HashMap::new();
     let mut dir_module_count: HashMap<String, usize> = HashMap::new();
     for m in modules {
         let rel = strip_path_prefix(&m.path, &common);
-        let parent = std::path::Path::new(&rel)
-            .parent()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
-        *dir_module_count.entry(parent).or_insert(0) += 1;
+        let parts: Vec<&str> = rel.split('/').collect();
+        // Count this module in every ancestor directory
+        for end in 1..parts.len() {
+            let dir = parts[..end].join("/");
+            *dir_module_count.entry(dir).or_insert(0) += 1;
+        }
     }
     for v in &result.violations {
-        let dir = strip_path_prefix(&v.dir_a, &common);
-        *dir_violation_severity.entry(dir).or_insert(0.0) += v.severity;
+        let a = strip_path_prefix(&v.dir_a, &common);
+        let b = strip_path_prefix(&v.dir_b, &common);
+        let parent = common_parent_of(&a, &b);
+        if !parent.is_empty() {
+            *dir_violation_severity.entry(parent).or_insert(0.0) += v.severity;
+        }
     }
 
     let tree = apply_scores(tree, &dir_violation_severity, &dir_module_count);
@@ -254,9 +262,10 @@ fn apply_scores(
             format!("{}/{}", path, node.name)
         };
 
-        if let Some(&s) = sev.get(&full_path) {
-            let modules = cnt.get(&full_path).copied().unwrap_or(1) as f64;
-            node.score = Some((100.0 * (1.0 - s / modules.max(1.0))).max(0.0));
+        // Always assign a score for non-leaf nodes so the sunburst is fully colored
+        if let Some(&modules) = cnt.get(&full_path) {
+            let s = sev.get(&full_path).copied().unwrap_or(0.0);
+            node.score = Some((100.0 * (1.0 - s / (modules as f64).max(1.0))).clamp(0.0, 100.0));
         }
 
         let child_path = if node.name == "root" {
@@ -294,6 +303,26 @@ fn find_common_path_prefix(paths: &[&str]) -> String {
         len -= 1;
     }
     first[..len].join("/")
+}
+
+/// Return the deepest common parent directory of two paths.
+/// e.g. ("a/b/c", "a/b/d") -> "a/b"
+fn common_parent_of(a: &str, b: &str) -> String {
+    let a_parts: Vec<&str> = a.split('/').collect();
+    let b_parts: Vec<&str> = b.split('/').collect();
+    let mut len = 0;
+    for (x, y) in a_parts.iter().zip(b_parts.iter()) {
+        if x == y {
+            len += 1;
+        } else {
+            break;
+        }
+    }
+    if len > 0 {
+        a_parts[..len].join("/")
+    } else {
+        String::new()
+    }
 }
 
 fn strip_path_prefix(path: &str, prefix: &str) -> String {

--- a/src/reporter/bundle.rs
+++ b/src/reporter/bundle.rs
@@ -25,10 +25,23 @@ struct DepEdge {
 }
 
 #[derive(Serialize)]
+struct CycleHop {
+    from: String,
+    to: String,
+    count: usize,
+}
+
+#[derive(Serialize)]
+struct CycleAtLevel {
+    hops: Vec<CycleHop>,
+}
+
+#[derive(Serialize)]
 struct BundleData {
     tree: SunburstNode,
     deps: Vec<DepEdge>,
     violation_deps: Vec<DepEdge>,
+    cycles: Vec<CycleAtLevel>,
 }
 
 pub fn generate_bundle_report(
@@ -232,10 +245,41 @@ fn build_data(modules: &[Module], dependencies: &[Dependency], result: &AuditRes
         }
     }
 
+    // Build per-cycle hop lists (directories + import counts) so the JS
+    // can project each cycle onto the current zoom level and highlight
+    // the participating siblings + the weakest hop to break.
+    let mut cycles: Vec<CycleAtLevel> = Vec::new();
+    for v in &result.violations {
+        if !v.is_circular {
+            continue;
+        }
+        if v.cycle_path.len() < 2 || v.cycle_hop_counts.is_empty() {
+            continue;
+        }
+        let mut hops: Vec<CycleHop> = Vec::new();
+        for i in 0..v.cycle_hop_counts.len() {
+            // cycle_path closes the loop, so cycle_path.len() == cycle_hop_counts.len() + 1
+            if i + 1 >= v.cycle_path.len() {
+                break;
+            }
+            let from = strip_path_prefix(&v.cycle_path[i], &common);
+            let to = strip_path_prefix(&v.cycle_path[i + 1], &common);
+            hops.push(CycleHop {
+                from,
+                to,
+                count: v.cycle_hop_counts[i],
+            });
+        }
+        if hops.len() >= 2 {
+            cycles.push(CycleAtLevel { hops });
+        }
+    }
+
     BundleData {
         tree,
         deps,
         violation_deps,
+        cycles,
     }
 }
 

--- a/src/reporter/bundle.rs
+++ b/src/reporter/bundle.rs
@@ -112,8 +112,20 @@ fn build_data(modules: &[Module], dependencies: &[Dependency], result: &AuditRes
 
     // Mark every ancestor directory of a circular violation so the user can
     // visually trace which subtrees contain cycles, even when the score for
-    // that directory is otherwise green.
+    // that directory is otherwise green. Marks both the cycle dir endpoints
+    // AND the directories of the actual files involved in each hop, so users
+    // can drill down to find the offending file.
     let mut cycle_ancestors: HashSet<String> = HashSet::new();
+
+    fn mark_path(path: &str, set: &mut HashSet<String>) {
+        let parts: Vec<&str> = path.split('/').collect();
+        // Skip the file itself; mark each ancestor directory
+        let depth = parts.len().saturating_sub(1);
+        for end in 1..=depth {
+            set.insert(parts[..end].join("/"));
+        }
+    }
+
     for v in &result.violations {
         if !v.is_circular {
             continue;
@@ -125,6 +137,28 @@ fn build_data(modules: &[Module], dependencies: &[Dependency], result: &AuditRes
             for end in 1..=parts.len() {
                 cycle_ancestors.insert(parts[..end].join("/"));
             }
+        }
+        // Also mark every file that participates in the cycle hops
+        for (from_file, to_file, _) in &v.cycle_hop_files {
+            if !from_file.is_empty() {
+                mark_path(&strip_path_prefix(from_file, &common), &mut cycle_ancestors);
+            }
+            if !to_file.is_empty() {
+                mark_path(&strip_path_prefix(to_file, &common), &mut cycle_ancestors);
+            }
+        }
+        // And the actual from_module / to_module
+        if !v.from_module.is_empty() {
+            mark_path(
+                &strip_path_prefix(&v.from_module, &common),
+                &mut cycle_ancestors,
+            );
+        }
+        if !v.to_module.is_empty() {
+            mark_path(
+                &strip_path_prefix(&v.to_module, &common),
+                &mut cycle_ancestors,
+            );
         }
     }
     fn mark_cycles(node: &mut SunburstNode, path: &str, ancestors: &HashSet<String>) {

--- a/src/reporter/bundle.rs
+++ b/src/reporter/bundle.rs
@@ -12,6 +12,8 @@ struct SunburstNode {
     score: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     value: Option<usize>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    has_cycle_in_subtree: bool,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     children: Vec<SunburstNode>,
 }
@@ -106,7 +108,46 @@ fn build_data(modules: &[Module], dependencies: &[Dependency], result: &AuditRes
         }
     }
 
-    let tree = apply_scores(tree, &dir_violation_severity, &dir_module_count);
+    let mut tree = apply_scores(tree, &dir_violation_severity, &dir_module_count);
+
+    // Mark every ancestor directory of a circular violation so the user can
+    // visually trace which subtrees contain cycles, even when the score for
+    // that directory is otherwise green.
+    let mut cycle_ancestors: HashSet<String> = HashSet::new();
+    for v in &result.violations {
+        if !v.is_circular {
+            continue;
+        }
+        let a = strip_path_prefix(&v.dir_a, &common);
+        let b = strip_path_prefix(&v.dir_b, &common);
+        for path in [a.as_str(), b.as_str()] {
+            let parts: Vec<&str> = path.split('/').collect();
+            for end in 1..=parts.len() {
+                cycle_ancestors.insert(parts[..end].join("/"));
+            }
+        }
+    }
+    fn mark_cycles(node: &mut SunburstNode, path: &str, ancestors: &HashSet<String>) {
+        let full_path = if path.is_empty() {
+            node.name.clone()
+        } else if node.name == "root" {
+            String::new()
+        } else {
+            format!("{}/{}", path, node.name)
+        };
+        if ancestors.contains(&full_path) {
+            node.has_cycle_in_subtree = true;
+        }
+        let child_path = if node.name == "root" {
+            String::new()
+        } else {
+            full_path
+        };
+        for child in &mut node.children {
+            mark_cycles(child, &child_path, ancestors);
+        }
+    }
+    mark_cycles(&mut tree, "", &cycle_ancestors);
 
     // Build cross-directory dependency edges (file-level, stripped paths)
     let mut deps: Vec<DepEdge> = Vec::new();
@@ -168,6 +209,7 @@ fn build_tree(dir_files: &BTreeMap<String, Vec<String>>) -> SunburstNode {
     let mut root = SunburstNode {
         name: "root".to_string(),
         score: None,
+        has_cycle_in_subtree: false,
         value: None,
         children: Vec::new(),
     };
@@ -204,6 +246,7 @@ fn build_tree(dir_files: &BTreeMap<String, Vec<String>>) -> SunburstNode {
                 current.children.push(SunburstNode {
                     name: part.to_string(),
                     score: None,
+                    has_cycle_in_subtree: false,
                     value: None,
                     children: Vec::new(),
                 });
@@ -225,6 +268,7 @@ fn build_tree(dir_files: &BTreeMap<String, Vec<String>>) -> SunburstNode {
             parent.children.push(SunburstNode {
                 name: file.clone(),
                 score: None,
+                has_cycle_in_subtree: false,
                 value: Some(1),
                 children: Vec::new(),
             });

--- a/src/reporter/bundle_template.html
+++ b/src/reporter/bundle_template.html
@@ -32,9 +32,12 @@ h1 span {{ color: #3b82f6; }}
 .edge {{ fill: none; cursor: default; }}
 .edge-normal {{ stroke: #94a3b8; stroke-opacity: 0.15; }}
 .edge-violation {{ stroke: #ef4444; stroke-opacity: 0.3; stroke-width: 1.5; }}
+.edge-cycle {{ stroke: #ef4444; stroke-opacity: 0.55; stroke-width: 2; }}
+.edge-cycle-weakest {{ stroke: #dc2626; stroke-opacity: 0.95; stroke-width: 3.5; }}
 .edge:hover {{ stroke-opacity: 1 !important; stroke-width: 3 !important; }}
 .edge-normal:hover {{ stroke: #3b82f6; }}
 .edge-violation:hover {{ stroke: #ef4444; }}
+.edge-cycle:hover, .edge-cycle-weakest:hover {{ stroke: #b91c1c; stroke-width: 4 !important; }}
 .stats {{
     font-size: 0.75rem; color: #94a3b8;
     margin-top: 0.75rem; text-align: center;
@@ -91,6 +94,7 @@ footer {{ margin-top: 1.5rem; font-size: 0.65rem; color: #cbd5e1; }}
     <span><span class="legend-dot" style="background:#ef4444"></span> needs attention</span>
     <span><span class="legend-dot" style="background:#94a3b8"></span> dependency</span>
     <span><span class="legend-dot" style="background:#ef4444; opacity:0.6"></span> violation</span>
+    <span><span class="legend-dot" style="background:#dc2626"></span> cycle (break this)</span>
 </div>
 
 <footer>{version}</footer>
@@ -101,8 +105,15 @@ const rawData = {json};
 const tooltip = document.getElementById("tooltip");
 const allDeps = rawData.deps;
 const violationDeps = rawData.violation_deps;
+const allCycles = rawData.cycles || [];
 let currentBeta = 0.85;
 let showViolationsOnly = false;
+
+// Per-zoom-level cycle state — recomputed on every zoom.
+// currentLevelCycles: array of cycle objects, each with edges and participants.
+// currentCycleParticipants: Set of arcs — union of all participant arcs at this level.
+let currentLevelCycles = [];
+let currentCycleParticipants = new Set();
 
 const width = Math.min(window.innerWidth - 40, 928);
 const height = width;
@@ -126,6 +137,11 @@ root.each(d => {{
 
 // Score-based fill color (always green/yellow/red, never rainbow)
 function fillColor(d) {{
+    // If this node is a direct participant in a cycle at the current zoom
+    // level, force RED so the offending sibling stands out clearly.
+    if (currentCycleParticipants.has(d)) {{
+        return d.children ? "rgba(220,38,38,0.55)" : "rgba(220,38,38,0.4)";
+    }}
     // If this node or any descendant contains a circular dependency,
     // force at least yellow so the user can visually trace cycles.
     if (d.data.has_cycle_in_subtree) {{
@@ -257,6 +273,48 @@ function aggregateEdges(deps, children) {{
     return Array.from(edgeMap.values());
 }}
 
+// Project rawData.cycles onto the current zoom's children. A cycle is
+// "alive" at this level when at least 2 hops cross between distinct
+// children (a self-edge — both ends inside the same child — collapses
+// and is dropped). The weakest remaining hop (fewest imports) is the
+// recommended break point.
+function computeLevelCycles() {{
+    currentLevelCycles = [];
+    currentCycleParticipants = new Set();
+    const children = currentZoomNode.children || [];
+    if (children.length < 2) return;
+
+    for (const cycle of allCycles) {{
+        const projected = [];
+        for (const hop of cycle.hops) {{
+            const f = findOwner(hop.from, children);
+            const t = findOwner(hop.to, children);
+            if (f && t && f !== t) {{
+                projected.push({{ from: f, to: t, count: hop.count }});
+            }}
+        }}
+        if (projected.length < 2) continue;
+
+        // Find the weakest hop (lowest import count) — the easiest break.
+        let weakestIdx = 0;
+        for (let i = 1; i < projected.length; i++) {{
+            if (projected[i].count < projected[weakestIdx].count) weakestIdx = i;
+        }}
+        const participants = new Set();
+        const edges = projected.map((e, i) => {{
+            participants.add(e.from);
+            participants.add(e.to);
+            return {{ ...e, weakest: i === weakestIdx }};
+        }});
+        currentLevelCycles.push({{ edges, participants }});
+        for (const p of participants) currentCycleParticipants.add(p);
+    }}
+}}
+
+function updateArcColors() {{
+    path.attr("fill", d => fillColor(d));
+}}
+
 function drawEdges() {{
     const children = currentZoomNode.children || [];
     if (children.length === 0) {{ edgeGroup.selectAll("path").remove(); return; }}
@@ -264,6 +322,18 @@ function drawEdges() {{
     const normalEdges = aggregateEdges(allDeps, children);
     const vEdges = aggregateEdges(violationDeps, children);
     const vSet = new Set(vEdges.map(e => e.from.fullPath + "|" + e.to.fullPath));
+
+    // Build a set of cycle edge keys so we can suppress duplicate normal/violation
+    // rendering of the same arc-to-arc edge — cycle edges take priority and are
+    // rendered separately (red, layered on top) below.
+    const cycleEdgeKeys = new Set();
+    const cycleEdgeFlat = [];
+    currentLevelCycles.forEach((cycle, cycleIdx) => {{
+        for (const e of cycle.edges) {{
+            cycleEdgeKeys.add(e.from.fullPath + "|" + e.to.fullPath);
+            cycleEdgeFlat.push({{ ...e, cycleIdx, participants: cycle.participants }});
+        }}
+    }});
 
     let displayEdges;
     if (showViolationsOnly) {{
@@ -274,28 +344,35 @@ function drawEdges() {{
             isViolation: vSet.has(e.from.fullPath + "|" + e.to.fullPath)
         }}));
     }}
+    // Drop normal/violation edges that will be re-rendered as red cycle edges.
+    displayEdges = displayEdges.filter(e =>
+        !cycleEdgeKeys.has(e.from.fullPath + "|" + e.to.fullPath)
+    );
 
     edgeGroup.selectAll("path").remove();
-    edgeGroup.selectAll("path")
+
+    function edgePath(d) {{
+        const a1 = (d.from.current.x0 + d.from.current.x1) / 2;
+        const r1 = d.from.current.y0 * radius;
+        const a2 = (d.to.current.x0 + d.to.current.x1) / 2;
+        const r2 = d.to.current.y0 * radius;
+
+        const x1 = Math.sin(a1) * r1;
+        const y1 = -Math.cos(a1) * r1;
+        const x2 = Math.sin(a2) * r2;
+        const y2 = -Math.cos(a2) * r2;
+
+        const cx = (1 - currentBeta) * (x1 + x2) / 2;
+        const cy = (1 - currentBeta) * (y1 + y2) / 2;
+
+        return `M${{x1}},${{y1}} Q${{cx}},${{cy}} ${{x2}},${{y2}}`;
+    }}
+
+    edgeGroup.selectAll("path.edge-base")
         .data(displayEdges)
         .join("path")
-        .attr("class", d => "edge " + (d.isViolation ? "edge-violation" : "edge-normal"))
-        .attr("d", d => {{
-            const a1 = (d.from.current.x0 + d.from.current.x1) / 2;
-            const r1 = d.from.current.y0 * radius;
-            const a2 = (d.to.current.x0 + d.to.current.x1) / 2;
-            const r2 = d.to.current.y0 * radius;
-
-            const x1 = Math.sin(a1) * r1;
-            const y1 = -Math.cos(a1) * r1;
-            const x2 = Math.sin(a2) * r2;
-            const y2 = -Math.cos(a2) * r2;
-
-            const cx = (1 - currentBeta) * (x1 + x2) / 2;
-            const cy = (1 - currentBeta) * (y1 + y2) / 2;
-
-            return `M${{x1}},${{y1}} Q${{cx}},${{cy}} ${{x2}},${{y2}}`;
-        }})
+        .attr("class", d => "edge edge-base " + (d.isViolation ? "edge-violation" : "edge-normal"))
+        .attr("d", edgePath)
         .attr("stroke-width", d => Math.min(1 + Math.log2(d.count + 1), 4))
         .style("pointer-events", "stroke")
         .on("mouseover", (event, d) => {{
@@ -310,8 +387,60 @@ function drawEdges() {{
             tooltip.style.top = (event.clientY - 10) + "px";
         }})
         .on("mouseout", () => {{ tooltip.style.opacity = 0; }});
+
+    // Layer cycle edges on top, in red. The weakest hop in each cycle is
+    // marked as the recommended break (brighter, thicker, dedicated tooltip).
+    edgeGroup.selectAll("path.edge-cyc")
+        .data(cycleEdgeFlat)
+        .join("path")
+        .attr("class", d => "edge edge-cyc " + (d.weakest ? "edge-cycle-weakest" : "edge-cycle"))
+        .attr("d", edgePath)
+        .style("pointer-events", "stroke")
+        .on("mouseover", (event, d) => {{
+            const fromName = d.from.data.name;
+            const toName = d.to.data.name;
+            const word = d.count === 1 ? "import" : "imports";
+            const breakHint = d.weakest
+                ? `<br><span style="color:#fca5a5">${{d.count}} ${{word}} &rarr; break this side</span>`
+                : `<br>${{d.count}} ${{word}} &middot; <span style="color:#fbbf24">cycle</span>`;
+            tooltip.innerHTML = `<strong>${{fromName}}</strong> &rarr; <strong>${{toName}}</strong>${{breakHint}}`;
+            tooltip.style.opacity = 1;
+            highlightCycle(d.participants);
+        }})
+        .on("mousemove", (event) => {{
+            tooltip.style.left = (event.clientX + 12) + "px";
+            tooltip.style.top = (event.clientY - 10) + "px";
+        }})
+        .on("mouseout", () => {{
+            tooltip.style.opacity = 0;
+            clearHighlight();
+        }});
 }}
 
+// Dim everything except the arcs/edges that belong to the hovered cycle.
+function highlightCycle(participants) {{
+    path.attr("fill-opacity", function(d) {{
+        if (!arcVisible(d.current)) return 0;
+        return participants.has(d) ? 1 : 0.18;
+    }});
+    edgeGroup.selectAll("path").attr("stroke-opacity", function(e) {{
+        return participants.has(e.from) && participants.has(e.to) ? 0.95 : 0.04;
+    }});
+    label.attr("fill-opacity", function(d) {{
+        if (!labelVisible(d.current)) return 0;
+        return participants.has(d) ? 1 : 0.2;
+    }});
+}}
+
+function clearHighlight() {{
+    path.attr("fill-opacity", d => arcVisible(d.current) ? 1 : 0);
+    // Setting stroke-opacity to null restores the value from the CSS class.
+    edgeGroup.selectAll("path").attr("stroke-opacity", null);
+    label.attr("fill-opacity", d => +labelVisible(d.current));
+}}
+
+computeLevelCycles();
+updateArcColors();
 drawEdges();
 
 // ── Auto-zoom to first meaningful level ──
@@ -345,6 +474,11 @@ function clicked(event, p) {{
     currentZoomNode = p;
 
     centerLabel.text(p.data.name === "root" ? "root" : p.data.name);
+
+    // Recompute which siblings are in cycles at the new zoom level so
+    // the arc fill (red for participants) matches what we're about to show.
+    computeLevelCycles();
+    updateArcColors();
 
     root.each(d => d.target = {{
         x0: Math.max(0, Math.min(1, (d.x0 - p.x0) / (p.x1 - p.x0))) * 2 * Math.PI,

--- a/src/reporter/bundle_template.html
+++ b/src/reporter/bundle_template.html
@@ -126,6 +126,19 @@ root.each(d => {{
 
 // Score-based fill color (always green/yellow/red, never rainbow)
 function fillColor(d) {{
+    // If this node or any descendant contains a circular dependency,
+    // force at least yellow so the user can visually trace cycles.
+    if (d.data.has_cycle_in_subtree) {{
+        // Use score to choose between yellow and red (downgrade green to yellow)
+        let node = d;
+        while (node) {{
+            if (node.data.score != null && node.data.score < 70) {{
+                return d.children ? "rgba(239,68,68,0.45)" : "rgba(239,68,68,0.25)";
+            }}
+            node = node.parent;
+        }}
+        return d.children ? "rgba(234,179,8,0.5)" : "rgba(234,179,8,0.3)";
+    }}
     // Walk up to find nearest score
     let node = d;
     while (node) {{

--- a/src/reporter/bundle_template.html
+++ b/src/reporter/bundle_template.html
@@ -301,15 +301,26 @@ function drawEdges() {{
 
 drawEdges();
 
-// ── Auto-zoom to first meaningful level (>= 2 children) ──
+// ── Auto-zoom to first meaningful level ──
+// Drill down while either:
+//   (a) the node has only 1 child (trivial), OR
+//   (b) one child holds >= 90% of the total value (e.g. main vs tiny debug/test)
 (function() {{
     let target = root;
-    while (target.children && target.children.length === 1) {{
-        target = target.children[0];
+    while (target.children && target.children.length > 0) {{
+        if (target.children.length === 1) {{
+            target = target.children[0];
+            continue;
+        }}
+        const total = target.value || 1;
+        const dominant = target.children.reduce((max, c) => (c.value || 0) > (max.value || 0) ? c : max, target.children[0]);
+        if ((dominant.value || 0) / total >= 0.9) {{
+            target = dominant;
+            continue;
+        }}
+        break;
     }}
     if (target !== root) {{
-        // Trigger a click-equivalent zoom without animation transitions
-        // (just snap to that level on initial render)
         clicked(null, target);
     }}
 }})();

--- a/src/reporter/bundle_template.html
+++ b/src/reporter/bundle_template.html
@@ -124,7 +124,7 @@ root.each(d => {{
     d.current = {{ x0: d.x0, x1: d.x1, y0: d.y0, y1: d.y1 }};
 }});
 
-// Score-based fill color
+// Score-based fill color (always green/yellow/red, never rainbow)
 function fillColor(d) {{
     // Walk up to find nearest score
     let node = d;
@@ -137,13 +137,8 @@ function fillColor(d) {{
         }}
         node = node.parent;
     }}
-    // Fallback: color by top-level ancestor
-    let top = d;
-    while (top.depth > 1) top = top.parent;
-    const color = d3.scaleOrdinal(d3.quantize(d3.interpolateRainbow, root.children ? root.children.length + 1 : 1));
-    const c = d3.color(color(top.data.name));
-    c.opacity = d.children ? 0.6 : 0.4;
-    return c + "";
+    // Fallback: assume healthy (green) when no score is available
+    return d.children ? "rgba(34,197,94,0.5)" : "rgba(34,197,94,0.3)";
 }}
 
 // Arc generator

--- a/src/reporter/bundle_template.html
+++ b/src/reporter/bundle_template.html
@@ -301,6 +301,19 @@ function drawEdges() {{
 
 drawEdges();
 
+// ── Auto-zoom to first meaningful level (>= 2 children) ──
+(function() {{
+    let target = root;
+    while (target.children && target.children.length === 1) {{
+        target = target.children[0];
+    }}
+    if (target !== root) {{
+        // Trigger a click-equivalent zoom without animation transitions
+        // (just snap to that level on initial render)
+        clicked(null, target);
+    }}
+}})();
+
 // ── Zoom on click ─────────────────────────────────────
 
 function clicked(event, p) {{

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -260,6 +260,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -291,6 +292,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -319,6 +321,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -416,6 +416,22 @@ fn short_name(path: &str) -> &str {
         .unwrap_or(path)
 }
 
+/// Render a file path as `parent: file.ext` for display.
+fn module_label(path: &str) -> String {
+    let p = std::path::Path::new(path);
+    let file = p.file_name().and_then(|f| f.to_str()).unwrap_or(path);
+    let parent = p
+        .parent()
+        .and_then(|d| d.file_name())
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+    if parent.is_empty() {
+        file.to_string()
+    } else {
+        format!("<span class=\"module-tag\">{}</span> {}", parent, file)
+    }
+}
+
 fn score_color(score: f64, green: f64, yellow: f64) -> &'static str {
     if score >= green {
         "#22c55e"
@@ -569,26 +585,25 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 } else {
                     "#6b7280"
                 };
-                let from_short = std::path::Path::new(&v.from_module)
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or(&v.from_module);
-                let to_short = std::path::Path::new(&v.to_module)
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or(&v.to_module);
+                let from_label = module_label(&v.from_module);
+                let to_label = module_label(&v.to_module);
                 violations_html.push_str(&format!(
                     "<div class=\"violation-card\">
                         <div class=\"violation-sev\" style=\"color:{}\">{:.2}</div>
                         <div class=\"violation-body\">
-                            <div class=\"violation-title\"><strong>{}</strong> &rarr; <strong>{}</strong></div>
+                            <div class=\"violation-title\">{} &rarr; {}</div>
                             <div class=\"violation-detail\" title=\"{}\">{}</div>
                             <div class=\"violation-detail\" title=\"{}\">{}</div>
                         </div>
                     </div>\n",
-                    sev_clr, v.severity, from_short, to_short,
-                    v.from_module, v.from_module,
-                    v.to_module, v.to_module,
+                    sev_clr,
+                    v.severity,
+                    from_label,
+                    to_label,
+                    v.from_module,
+                    v.from_module,
+                    v.to_module,
+                    v.to_module,
                 ));
             }
             violations_html.push_str("</div>\n");
@@ -610,17 +625,11 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 } else {
                     "#6b7280"
                 };
-                let from_short = std::path::Path::new(&v.from_module)
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or(&v.from_module);
-                let to_short = std::path::Path::new(&v.to_module)
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or(&v.to_module);
+                let from_label = module_label(&v.from_module);
+                let to_label = module_label(&v.to_module);
                 violations_html.push_str(&format!(
                     "<tr><td><span class=\"severity\" style=\"color:{}\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
-                    sev_clr, v.severity, v.from_module, from_short, v.to_module, to_short,
+                    sev_clr, v.severity, v.from_module, from_label, v.to_module, to_label,
                 ));
             }
             violations_html.push_str("</table>\n");
@@ -644,17 +653,11 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
         for v in &sorted_metrics {
-            let from_short = std::path::Path::new(&v.from_module)
-                .file_name()
-                .and_then(|f| f.to_str())
-                .unwrap_or(&v.from_module);
-            let to_short = std::path::Path::new(&v.to_module)
-                .file_name()
-                .and_then(|f| f.to_str())
-                .unwrap_or(&v.to_module);
+            let from_label = module_label(&v.from_module);
+            let to_label = module_label(&v.to_module);
             violations_html.push_str(&format!(
                 "<tr><td><span class=\"severity\" style=\"color:#94a3b8\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
-                v.severity, v.from_module, from_short, v.to_module, to_short,
+                v.severity, v.from_module, from_label, v.to_module, to_label,
             ));
         }
         violations_html.push_str("</table>\n");
@@ -714,6 +717,7 @@ details[open] summary.cycle-path::before {{ transform: rotate(90deg); }}
 .footer {{ margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e2e8f0; font-size: 0.75rem; color: #94a3b8; }}
 .violations-promoted {{ margin-bottom: 1rem; }}
 .section-hint {{ font-size: 0.75rem; color: #64748b; margin-bottom: 0.6rem; font-style: italic; }}
+.module-tag {{ display: inline-block; background: #e0f2fe; color: #075985; font-size: 0.7rem; font-weight: 600; padding: 0.05rem 0.35rem; border-radius: 3px; margin-right: 0.25rem; vertical-align: middle; }}
 .score-hint {{ font-size: 0.75rem; color: #64748b; margin-top: 0.5rem; line-height: 1.4; }}
 .info-icon {{ color: #94a3b8; font-size: 0.7rem; cursor: help; margin-left: 0.15rem; }}
 .summary-card[title] {{ cursor: help; }}

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -418,11 +418,12 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
         let banner_clr = score_color(data.total_score, data.score_green, data.score_yellow);
         format!(
             "<div class=\"summary\" style=\"background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:0.75rem 1rem;margin-bottom:1rem\">
-                <div class=\"summary-card\"><div class=\"label\">Project Score</div><div class=\"value\" style=\"color:{}\">{:.1}</div></div>
+                <div class=\"summary-card\" title=\"Overall project health, computed from all violations across the entire codebase. This is the canonical score reported by audit and used in CI gates.\"><div class=\"label\">Project Score <span class=\"info-icon\">&#9432;</span></div><div class=\"value\" style=\"color:{}\">{:.1}</div></div>
                 <div class=\"summary-card\"><div class=\"label\">Total Modules</div><div class=\"value\">{}</div></div>
                 <div class=\"summary-card\"><div class=\"label\">Total Violations</div><div class=\"value\">{}</div></div>
-                <div class=\"summary-card\"><div class=\"label\">Total XS</div><div class=\"value\">{}</div></div>
-            </div>",
+                <div class=\"summary-card\" title=\"Total Excess: imports that need to be removed across all violations to reach a clean state.\"><div class=\"label\">Total XS <span class=\"info-icon\">&#9432;</span></div><div class=\"value\">{}</div></div>
+            </div>
+            <p class=\"score-hint\">The <strong>Project Score</strong> above is the overall codebase health. The <strong>Health Score</strong> in the cards below reflects only this directory &mdash; a directory can be 100/100 while the project score is lower because violations live in subdirectories.</p>",
             banner_clr, data.total_score, data.total_modules, data.total_violations, data.total_xs
         )
     } else {
@@ -533,11 +534,11 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
         });
 
         let promoted: Vec<&&ViolationInfo> = sorted.iter().take(5).collect();
-        let listed: Vec<&&ViolationInfo> = sorted.iter().skip(5).take(20).collect();
-        let hidden: Vec<&&ViolationInfo> = sorted.iter().skip(25).collect();
+        let rest: Vec<&&ViolationInfo> = sorted.iter().skip(5).collect();
 
         if !promoted.is_empty() {
             violations_html.push_str("<div class=\"violations-promoted\">\n");
+            violations_html.push_str("<p class=\"section-hint\">Top 5 violations by severity &mdash; tackle these first for the biggest score impact.</p>\n");
             for v in &promoted {
                 let sev_clr = if v.severity >= data.critical_severity {
                     "#ef4444"
@@ -571,15 +572,15 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
             violations_html.push_str("</div>\n");
         }
 
-        // Tier 2: Listed (next 20 in a compact table)
-        if !listed.is_empty() {
+        // Show ALL remaining violations always (no hiding behind disclosure)
+        if !rest.is_empty() {
             violations_html.push_str(&format!(
-                "<details class=\"violations-section\" open><summary>Next {} violations</summary>\n",
-                listed.len()
+                "<h3 style=\"font-size:0.95rem;color:#475569;margin:1.25rem 0 0.5rem\">All {} violations</h3>\n",
+                coupling_violations.len()
             ));
             violations_html.push_str("<table class=\"violations\">\n");
             violations_html.push_str("<tr><th>Severity</th><th>From</th><th>To</th></tr>\n");
-            for v in &listed {
+            for v in &rest {
                 let sev_clr = if v.severity >= data.critical_severity {
                     "#ef4444"
                 } else if v.severity >= 0.2 {
@@ -600,39 +601,7 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                     sev_clr, v.severity, v.from_module, from_short, v.to_module, to_short,
                 ));
             }
-            violations_html.push_str("</table>\n</details>\n");
-        }
-
-        // Tier 3: Hidden behind disclosure
-        if !hidden.is_empty() {
-            violations_html.push_str(&format!(
-                "<details class=\"violations-section\"><summary>Show all {} remaining violations</summary>\n",
-                hidden.len()
-            ));
-            violations_html.push_str("<table class=\"violations\">\n");
-            violations_html.push_str("<tr><th>Severity</th><th>From</th><th>To</th></tr>\n");
-            for v in &hidden {
-                let sev_clr = if v.severity >= data.critical_severity {
-                    "#ef4444"
-                } else if v.severity >= 0.2 {
-                    "#eab308"
-                } else {
-                    "#6b7280"
-                };
-                let from_short = std::path::Path::new(&v.from_module)
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or(&v.from_module);
-                let to_short = std::path::Path::new(&v.to_module)
-                    .file_name()
-                    .and_then(|f| f.to_str())
-                    .unwrap_or(&v.to_module);
-                violations_html.push_str(&format!(
-                    "<tr><td><span class=\"severity\" style=\"color:{}\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
-                    sev_clr, v.severity, v.from_module, from_short, v.to_module, to_short,
-                ));
-            }
-            violations_html.push_str("</table>\n</details>\n");
+            violations_html.push_str("</table>\n");
         }
     }
 
@@ -689,6 +658,10 @@ details[open] summary.cycle-path::before {{ transform: rotate(90deg); }}
 .snapshot {{ font-size: 0.75rem; color: #94a3b8; margin-top: 0.5rem; }}
 .footer {{ margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e2e8f0; font-size: 0.75rem; color: #94a3b8; }}
 .violations-promoted {{ margin-bottom: 1rem; }}
+.section-hint {{ font-size: 0.75rem; color: #64748b; margin-bottom: 0.6rem; font-style: italic; }}
+.score-hint {{ font-size: 0.75rem; color: #64748b; margin-top: 0.5rem; line-height: 1.4; }}
+.info-icon {{ color: #94a3b8; font-size: 0.7rem; cursor: help; margin-left: 0.15rem; }}
+.summary-card[title] {{ cursor: help; }}
 .violation-card {{ display: flex; align-items: center; gap: 1rem; background: #fff; border: 1px solid #fecaca; border-left: 4px solid #ef4444; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 0.5rem; }}
 .violation-sev {{ font-weight: 800; font-size: 1.05rem; min-width: 50px; text-align: right; }}
 .violation-body {{ flex: 1; font-size: 0.85rem; }}
@@ -709,16 +682,16 @@ details[open] summary.cycle-path::before {{ transform: rotate(90deg); }}
 {project_banner}
 
 <div class="summary">
-    <div class="summary-card">
-        <div class="label">Health Score</div>
+    <div class="summary-card" title="Health Score for this directory only. Computed from violations originating here (not from subdirectories).">
+        <div class="label">Health Score <span class="info-icon">&#9432;</span></div>
         <div class="value score-big">{score:.1}</div>
     </div>
-    <div class="summary-card">
-        <div class="label">Modules</div>
+    <div class="summary-card" title="Total source files in this directory and its subdirectories.">
+        <div class="label">Modules <span class="info-icon">&#9432;</span></div>
         <div class="value">{modules}</div>
     </div>
-    <div class="summary-card">
-        <div class="label">Violations</div>
+    <div class="summary-card" title="Violations that have this directory as their common parent (i.e., the directory pair both belong to this subtree).">
+        <div class="label">Violations <span class="info-icon">&#9432;</span></div>
         <div class="value">{violations}</div>
     </div>
 </div>

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -519,36 +519,121 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
     }
 
     if !coupling_violations.is_empty() {
-        violations_html.push_str("<h2>Coupling Violations</h2>\n<table class=\"violations\">\n");
-        violations_html
-            .push_str("<tr><th>Severity</th><th>From</th><th>To</th><th>Details</th></tr>\n");
-        for v in &coupling_violations {
-            let sev_clr = if v.severity >= data.critical_severity {
-                "#ef4444"
-            } else if v.severity >= 0.2 {
-                "#eab308"
-            } else {
-                "#6b7280"
-            };
-            let from_short = std::path::Path::new(&v.from_module)
-                .file_name()
-                .and_then(|f| f.to_str())
-                .unwrap_or(&v.from_module);
-            let to_short = std::path::Path::new(&v.to_module)
-                .file_name()
-                .and_then(|f| f.to_str())
-                .unwrap_or(&v.to_module);
-            violations_html.push_str(&format!(
-                "<tr>
-                    <td><span class=\"severity\" style=\"color:{}\">{:.2}</span></td>
-                    <td title=\"{}\">{}</td>
-                    <td title=\"{}\">{}</td>
-                    <td>Coupling</td>
-                </tr>\n",
-                sev_clr, v.severity, v.from_module, from_short, v.to_module, to_short,
-            ));
+        violations_html.push_str(&format!(
+            "<h2>Coupling Violations <small style=\"font-weight:400;color:#64748b\">({} total)</small></h2>\n",
+            coupling_violations.len()
+        ));
+
+        // Tier 1: Promoted (top 5 by severity, card layout)
+        let mut sorted = coupling_violations.clone();
+        sorted.sort_by(|a, b| {
+            b.severity
+                .partial_cmp(&a.severity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        let promoted: Vec<&&ViolationInfo> = sorted.iter().take(5).collect();
+        let listed: Vec<&&ViolationInfo> = sorted.iter().skip(5).take(20).collect();
+        let hidden: Vec<&&ViolationInfo> = sorted.iter().skip(25).collect();
+
+        if !promoted.is_empty() {
+            violations_html.push_str("<div class=\"violations-promoted\">\n");
+            for v in &promoted {
+                let sev_clr = if v.severity >= data.critical_severity {
+                    "#ef4444"
+                } else if v.severity >= 0.2 {
+                    "#eab308"
+                } else {
+                    "#6b7280"
+                };
+                let from_short = std::path::Path::new(&v.from_module)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(&v.from_module);
+                let to_short = std::path::Path::new(&v.to_module)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(&v.to_module);
+                violations_html.push_str(&format!(
+                    "<div class=\"violation-card\">
+                        <div class=\"violation-sev\" style=\"color:{}\">{:.2}</div>
+                        <div class=\"violation-body\">
+                            <div class=\"violation-title\"><strong>{}</strong> &rarr; <strong>{}</strong></div>
+                            <div class=\"violation-detail\" title=\"{}\">{}</div>
+                            <div class=\"violation-detail\" title=\"{}\">{}</div>
+                        </div>
+                    </div>\n",
+                    sev_clr, v.severity, from_short, to_short,
+                    v.from_module, v.from_module,
+                    v.to_module, v.to_module,
+                ));
+            }
+            violations_html.push_str("</div>\n");
         }
-        violations_html.push_str("</table>\n");
+
+        // Tier 2: Listed (next 20 in a compact table)
+        if !listed.is_empty() {
+            violations_html.push_str(&format!(
+                "<details class=\"violations-section\" open><summary>Next {} violations</summary>\n",
+                listed.len()
+            ));
+            violations_html.push_str("<table class=\"violations\">\n");
+            violations_html.push_str("<tr><th>Severity</th><th>From</th><th>To</th></tr>\n");
+            for v in &listed {
+                let sev_clr = if v.severity >= data.critical_severity {
+                    "#ef4444"
+                } else if v.severity >= 0.2 {
+                    "#eab308"
+                } else {
+                    "#6b7280"
+                };
+                let from_short = std::path::Path::new(&v.from_module)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(&v.from_module);
+                let to_short = std::path::Path::new(&v.to_module)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(&v.to_module);
+                violations_html.push_str(&format!(
+                    "<tr><td><span class=\"severity\" style=\"color:{}\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
+                    sev_clr, v.severity, v.from_module, from_short, v.to_module, to_short,
+                ));
+            }
+            violations_html.push_str("</table>\n</details>\n");
+        }
+
+        // Tier 3: Hidden behind disclosure
+        if !hidden.is_empty() {
+            violations_html.push_str(&format!(
+                "<details class=\"violations-section\"><summary>Show all {} remaining violations</summary>\n",
+                hidden.len()
+            ));
+            violations_html.push_str("<table class=\"violations\">\n");
+            violations_html.push_str("<tr><th>Severity</th><th>From</th><th>To</th></tr>\n");
+            for v in &hidden {
+                let sev_clr = if v.severity >= data.critical_severity {
+                    "#ef4444"
+                } else if v.severity >= 0.2 {
+                    "#eab308"
+                } else {
+                    "#6b7280"
+                };
+                let from_short = std::path::Path::new(&v.from_module)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(&v.from_module);
+                let to_short = std::path::Path::new(&v.to_module)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .unwrap_or(&v.to_module);
+                violations_html.push_str(&format!(
+                    "<tr><td><span class=\"severity\" style=\"color:{}\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
+                    sev_clr, v.severity, v.from_module, from_short, v.to_module, to_short,
+                ));
+            }
+            violations_html.push_str("</table>\n</details>\n");
+        }
     }
 
     let is_root = dir_path == data.root_path;
@@ -603,6 +688,17 @@ details[open] summary.cycle-path::before {{ transform: rotate(90deg); }}
 .violations {{ margin-bottom: 1.5rem; }}
 .snapshot {{ font-size: 0.75rem; color: #94a3b8; margin-top: 0.5rem; }}
 .footer {{ margin-top: 2rem; padding-top: 1rem; border-top: 1px solid #e2e8f0; font-size: 0.75rem; color: #94a3b8; }}
+.violations-promoted {{ margin-bottom: 1rem; }}
+.violation-card {{ display: flex; align-items: center; gap: 1rem; background: #fff; border: 1px solid #fecaca; border-left: 4px solid #ef4444; border-radius: 6px; padding: 0.75rem 1rem; margin-bottom: 0.5rem; }}
+.violation-sev {{ font-weight: 800; font-size: 1.05rem; min-width: 50px; text-align: right; }}
+.violation-body {{ flex: 1; font-size: 0.85rem; }}
+.violation-title {{ color: #1e293b; margin-bottom: 0.25rem; }}
+.violation-detail {{ color: #6b7280; font-size: 0.7rem; word-break: break-all; }}
+.violations-section {{ background: #f8fafc; border: 1px solid #e2e8f0; border-radius: 6px; padding: 0.5rem 1rem; margin-bottom: 0.75rem; }}
+.violations-section > summary {{ list-style: revert; cursor: pointer; font-weight: 600; color: #475569; font-size: 0.9rem; padding: 0.25rem 0; user-select: none; }}
+.violations-section[open] > summary {{ margin-bottom: 0.5rem; border-bottom: 1px solid #e2e8f0; padding-bottom: 0.5rem; }}
+.violations-section > summary::before {{ content: ''; }}
+.violations-section > summary::marker {{ display: revert; content: revert; }}
 </style>
 </head>
 <body>

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -15,6 +15,7 @@ struct DirNode {
     children_dirs: Vec<String>,
     files: Vec<String>,
     violations_here: Vec<ViolationInfo>,
+    coupling_metrics_here: Vec<ViolationInfo>,
     has_deep_violations: bool,
     score: f64,
     module_count: usize,
@@ -114,6 +115,7 @@ fn build_report_data(
                         children_dirs: Vec::new(),
                         files: Vec::new(),
                         violations_here: Vec::new(),
+                        coupling_metrics_here: Vec::new(),
                         has_deep_violations: false,
                         score: 100.0,
                         module_count: 0,
@@ -138,6 +140,7 @@ fn build_report_data(
                 children_dirs: Vec::new(),
                 files: Vec::new(),
                 violations_here: Vec::new(),
+                coupling_metrics_here: Vec::new(),
                 has_deep_violations: false,
                 score: 100.0,
                 module_count: 0,
@@ -240,6 +243,25 @@ fn build_report_data(
 
         if let Some(dir) = dirs.get_mut(&parent) {
             dir.violations_here.push(info);
+        }
+    }
+
+    // Distribute coupling metrics (informational, not violations) to directories
+    for cm in &result.coupling_metrics {
+        let parent = find_common_parent(&cm.dir_a, &cm.dir_b);
+        let info = ViolationInfo {
+            from_module: cm.from_module.clone(),
+            to_module: cm.to_module.clone(),
+            severity: cm.severity,
+            is_circular: false,
+            circular_direction: None,
+            cycle_path: Vec::new(),
+            cycle_hop_files: Vec::new(),
+            cycle_order: 0,
+            cycle_hop_counts: Vec::new(),
+        };
+        if let Some(dir) = dirs.get_mut(&parent) {
+            dir.coupling_metrics_here.push(info);
         }
     }
 
@@ -605,6 +627,39 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
         }
     }
 
+    // Coupling Metrics — informational sibling coupling pairs (not violations)
+    if !dir.coupling_metrics_here.is_empty() {
+        violations_html.push_str(&format!(
+            "<h2>Coupling Metrics <small style=\"font-weight:400;color:#64748b\">({} sibling coupling pair{})</small></h2>\n",
+            dir.coupling_metrics_here.len(),
+            if dir.coupling_metrics_here.len() == 1 { "" } else { "s" }
+        ));
+        violations_html.push_str("<p class=\"section-hint\">Sibling directories that import each other. Informational &mdash; not flagged as violations in actionable mode. Use to gauge coupling density.</p>\n");
+        violations_html.push_str("<table class=\"violations\">\n");
+        violations_html.push_str("<tr><th>Severity</th><th>From</th><th>To</th></tr>\n");
+        let mut sorted_metrics = dir.coupling_metrics_here.clone();
+        sorted_metrics.sort_by(|a, b| {
+            b.severity
+                .partial_cmp(&a.severity)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+        for v in &sorted_metrics {
+            let from_short = std::path::Path::new(&v.from_module)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(&v.from_module);
+            let to_short = std::path::Path::new(&v.to_module)
+                .file_name()
+                .and_then(|f| f.to_str())
+                .unwrap_or(&v.to_module);
+            violations_html.push_str(&format!(
+                "<tr><td><span class=\"severity\" style=\"color:#94a3b8\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
+                v.severity, v.from_module, from_short, v.to_module, to_short,
+            ));
+        }
+        violations_html.push_str("</table>\n");
+    }
+
     let is_root = dir_path == data.root_path;
     let title = if is_root {
         "noupling Report".to_string()
@@ -877,6 +932,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -904,6 +960,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -937,6 +994,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -986,6 +1044,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -416,19 +416,38 @@ fn short_name(path: &str) -> &str {
         .unwrap_or(path)
 }
 
-/// Render a file path as `parent: file.ext` for display.
-fn module_label(path: &str) -> String {
+/// Render a file path as `relative/path: file.ext` for display.
+/// `current_dir` is the directory of the page we're rendering — paths are
+/// shown relative to it so users can see where each file lives.
+fn module_label(path: &str, current_dir: &str) -> String {
     let p = std::path::Path::new(path);
     let file = p.file_name().and_then(|f| f.to_str()).unwrap_or(path);
     let parent = p
         .parent()
-        .and_then(|d| d.file_name())
-        .and_then(|f| f.to_str())
-        .unwrap_or("");
-    if parent.is_empty() {
+        .map(|d| d.to_string_lossy().to_string())
+        .unwrap_or_default();
+
+    // Strip the current_dir prefix so the displayed path is relative
+    let relative = if !current_dir.is_empty() {
+        let prefix = format!("{}/", current_dir);
+        if let Some(stripped) = parent.strip_prefix(&prefix) {
+            stripped.to_string()
+        } else if parent == current_dir {
+            String::new()
+        } else {
+            parent.clone()
+        }
+    } else {
+        parent.clone()
+    };
+
+    if relative.is_empty() {
         file.to_string()
     } else {
-        format!("<span class=\"module-tag\">{}</span> {}", parent, file)
+        format!(
+            "<span class=\"module-tag\" title=\"{}\">{}</span> {}",
+            parent, relative, file
+        )
     }
 }
 
@@ -585,8 +604,8 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 } else {
                     "#6b7280"
                 };
-                let from_label = module_label(&v.from_module);
-                let to_label = module_label(&v.to_module);
+                let from_label = module_label(&v.from_module, dir_path);
+                let to_label = module_label(&v.to_module, dir_path);
                 violations_html.push_str(&format!(
                     "<div class=\"violation-card\">
                         <div class=\"violation-sev\" style=\"color:{}\">{:.2}</div>
@@ -625,8 +644,8 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 } else {
                     "#6b7280"
                 };
-                let from_label = module_label(&v.from_module);
-                let to_label = module_label(&v.to_module);
+                let from_label = module_label(&v.from_module, dir_path);
+                let to_label = module_label(&v.to_module, dir_path);
                 violations_html.push_str(&format!(
                     "<tr><td><span class=\"severity\" style=\"color:{}\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
                     sev_clr, v.severity, v.from_module, from_label, v.to_module, to_label,
@@ -653,8 +672,8 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 .unwrap_or(std::cmp::Ordering::Equal)
         });
         for v in &sorted_metrics {
-            let from_label = module_label(&v.from_module);
-            let to_label = module_label(&v.to_module);
+            let from_label = module_label(&v.from_module, dir_path);
+            let to_label = module_label(&v.to_module, dir_path);
             violations_html.push_str(&format!(
                 "<tr><td><span class=\"severity\" style=\"color:#94a3b8\">{:.2}</span></td><td title=\"{}\">{}</td><td title=\"{}\">{}</td></tr>\n",
                 v.severity, v.from_module, from_label, v.to_module, to_label,

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1283,6 +1283,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1315,6 +1316,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1344,6 +1346,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1367,6 +1370,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1392,6 +1396,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1417,6 +1422,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1450,6 +1456,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 
@@ -1475,6 +1482,7 @@ mod tests {
             critical_path: Vec::new(),
             violation_age: ViolationAgeSummary::default(),
             coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
             suppressed_count: 0,
         };
 


### PR DESCRIPTION
## Summary

User feedback after #156: hiding violations behind \"Show all\" disclosure felt like data was missing, and \"Project Score 95\" vs \"Health Score 100\" was confusing without explanation.

## Changes

### Show all violations
- Remove the \"Show all N remaining\" disclosure
- Top 5 still promoted in card layout for prioritization
- ALL remaining violations listed in a default-visible table below

### Score explainers
- Hover tooltips on every summary card with info icon (&#9432;)
- Inline hint paragraph below project banner: \"a directory can be 100/100 while the project score is lower because violations live in subdirectories\"
- Italic note above top 5 cards: \"Top 5 violations by severity — tackle these first for the biggest score impact\"

## Why

Users want to see ALL violations all the time, just prioritized. The disclosure pattern made them feel like the report was hiding data. The score difference between project-level and per-directory was an additional cognitive barrier.

## Test plan

- [x] cargo check, cargo clippy, cargo fmt all pass
- [x] Builds and runs

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)