### PR TITLE
feat: dependency direction classification (#168)

### DIFF
--- a/docs/superpowers/specs/2026-04-19-dependency-direction-design.md
+++ b/docs/superpowers/specs/2026-04-19-dependency-direction-design.md
@@ -1,0 +1,64 @@
+# Phase 1: Dependency Direction Classification
+
+**Issue:** #168
+**Part of:** #167 — Software Dependency Risk Framework (RRI/TRI)
+**Date:** 2026-04-19
+
+## Purpose
+
+Add a `DependencyDirection` enum that classifies every violation by its architectural direction. This is the foundation for Phase 2 (severity weights + RRI calculation) where each direction gets a distinct risk weight.
+
+## Direction Enum
+
+```rust
+pub enum DependencyDirection {
+    Downward,  // parent dir imports from child dir (weight 2 in Phase 2)
+    Sibling,   // same-level dirs import each other (weight 4 in Phase 2)
+    Upward,    // child dir imports from parent dir (weight 6 in Phase 2)
+    Circular,  // cycle between dirs (weight 10 in Phase 2)
+}
+```
+
+Derives: `Debug`, `Clone`, `Serialize`, `Deserialize`, `PartialEq`, `Eq`.
+Serde renames variants to lowercase (`"downward"`, `"sibling"`, `"upward"`, `"circular"`).
+
+## Classification Rules
+
+Direction is a **violation-level** classification, not per-import:
+
+| Condition | Direction |
+|-----------|-----------|
+| `is_circular = true` | `Circular` |
+| All other violations (sibling-pair coupling) | `Sibling` |
+
+`Downward` and `Upward` are defined but unused until Phase 2 adds detection for those dependency types.
+
+## Changes
+
+### `src/core/mod.rs`
+- Add `DependencyDirection` enum with serde support
+- Add serde roundtrip test for the enum
+
+### `src/analyzer/mod.rs`
+- Add `pub direction: DependencyDirection` field to `CouplingViolation`
+- Set `Circular` at all circular violation construction sites (line ~863, ~602)
+- Set `Sibling` at all coupling violation construction sites (line ~903, ~947)
+- Update `make_coupling` test helper to include `direction: Sibling`
+- Add test: verify circular violations get `Circular`, sibling violations get `Sibling`
+
+### `src/baseline.rs`
+- Update `make_coupling` test helper to include `direction` field
+
+## Not In Scope
+
+- New violation detection (upward/downward) — Phase 2
+- Weight/RRI calculation — Phase 2
+- Report display changes — Phase 6
+- External/transitive dependencies — Phase 7
+
+## Tests
+
+1. `DependencyDirection` serde roundtrip (all 4 variants)
+2. Sibling coupling violations classified as `Sibling`
+3. Circular dependency violations classified as `Circular`
+4. All 185 existing tests pass with new field

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -6,7 +6,7 @@
 use fxhash::{FxHashMap, FxHashSet};
 use std::collections::BTreeMap;
 
-use crate::core::{Dependency, Module};
+use crate::core::{Dependency, DependencyDirection, Module};
 
 /// A detected coupling violation or circular dependency between modules.
 #[derive(Debug, Clone)]
@@ -27,6 +27,8 @@ pub struct CouplingViolation {
     pub weight: usize,
     /// Severity score. Coupling: `weight/(depth+1)`. Circular: `modules/(depth+1)/10`.
     pub severity: f64,
+    /// Architectural direction of this dependency (sibling, circular, etc.).
+    pub direction: DependencyDirection,
     /// Whether this is a circular dependency (vs. a coupling violation).
     pub is_circular: bool,
     /// For circular deps: the full cycle path as directory paths.
@@ -869,6 +871,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
                 depth,
                 weight: 0,
                 severity: modules.len() as f64 / (depth as f64 + 1.0) / 10.0,
+                direction: DependencyDirection::Circular,
                 is_circular: true,
                 cycle_path: cycle.dir_path.clone(),
                 cycle_hop_files: cycle.hop_files.clone(),
@@ -915,6 +918,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
                                                     depth,
                                                     weight: 1,
                                                     severity: 1.0 / (depth as f64 + 1.0),
+                                                    direction: DependencyDirection::Sibling,
                                                     is_circular: false,
                                                     cycle_path: Vec::new(),
                                                     cycle_hop_files: Vec::new(),
@@ -959,6 +963,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
                                                     depth,
                                                     weight: 1,
                                                     severity: 1.0 / (depth as f64 + 1.0),
+                                                    direction: DependencyDirection::Sibling,
                                                     is_circular: false,
                                                     cycle_path: Vec::new(),
                                                     cycle_hop_files: Vec::new(),
@@ -1916,6 +1921,41 @@ mod tests {
     }
 
     #[test]
+    fn sibling_violations_have_sibling_direction() {
+        let modules = vec![
+            make_module("a", "src/alpha/mod.rs"),
+            make_module("b", "src/beta/mod.rs"),
+        ];
+        let deps = vec![make_dep("a", "b", 1)];
+        let result = audit(&modules, &deps);
+        let siblings: Vec<&CouplingViolation> = result
+            .violations
+            .iter()
+            .filter(|v| !v.is_circular)
+            .collect();
+        assert!(!siblings.is_empty(), "Should have sibling violations");
+        for v in siblings {
+            assert_eq!(v.direction, DependencyDirection::Sibling);
+        }
+    }
+
+    #[test]
+    fn circular_violations_have_circular_direction() {
+        let modules = vec![
+            make_module("a", "src/alpha/mod.rs"),
+            make_module("b", "src/beta/mod.rs"),
+        ];
+        let deps = vec![make_dep("a", "b", 1), make_dep("b", "a", 5)];
+        let result = audit(&modules, &deps);
+        let circular: Vec<&CouplingViolation> =
+            result.violations.iter().filter(|v| v.is_circular).collect();
+        assert!(!circular.is_empty(), "Should have circular violations");
+        for v in circular {
+            assert_eq!(v.direction, DependencyDirection::Circular);
+        }
+    }
+
+    #[test]
     fn empty_project_scores_100() {
         let result = audit(&[], &[]);
         assert!((result.score - 100.0).abs() < f64::EPSILON);
@@ -2394,6 +2434,7 @@ mod tests {
             depth: 1,
             weight: 1,
             severity: 0.5,
+            direction: DependencyDirection::Sibling,
             is_circular: false,
             cycle_path: Vec::new(),
             cycle_hop_files: Vec::new(),
@@ -2420,6 +2461,7 @@ mod tests {
             depth: 1,
             weight: 1,
             severity: 0.5,
+            direction: DependencyDirection::Sibling,
             is_circular: false,
             cycle_path: Vec::new(),
             cycle_hop_files: Vec::new(),

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -9,7 +9,6 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use crate::analyzer::{AuditResult, CouplingViolation};
-use crate::core::DependencyDirection;
 
 /// A fingerprint that uniquely identifies a violation.
 fn fingerprint(v: &CouplingViolation) -> String {
@@ -115,6 +114,7 @@ fn chrono_now() -> String {
 mod tests {
     use super::*;
     use crate::analyzer::ViolationAgeSummary;
+    use crate::core::DependencyDirection;
 
     fn make_coupling(from: &str, to: &str) -> CouplingViolation {
         CouplingViolation {

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -9,6 +9,7 @@ use std::collections::HashSet;
 use std::path::Path;
 
 use crate::analyzer::{AuditResult, CouplingViolation};
+use crate::core::DependencyDirection;
 
 /// A fingerprint that uniquely identifies a violation.
 fn fingerprint(v: &CouplingViolation) -> String {
@@ -125,6 +126,7 @@ mod tests {
             weight: 1,
             depth: 0,
             severity: 0.5,
+            direction: DependencyDirection::Sibling,
             is_circular: false,
             cycle_path: Vec::new(),
             cycle_hop_files: Vec::new(),

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,6 +2,26 @@
 
 use serde::{Deserialize, Serialize};
 
+/// The architectural direction of a dependency between two modules.
+///
+/// Used to assign risk weights in the dependency risk framework:
+/// downward (2) < sibling (4) < upward (6) < circular (10).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DependencyDirection {
+    /// Parent directory imports from child directory. Low risk.
+    #[serde(rename = "downward")]
+    Downward,
+    /// Same-level directories import each other. Moderate risk.
+    #[serde(rename = "sibling")]
+    Sibling,
+    /// Child directory imports from parent directory. High risk.
+    #[serde(rename = "upward")]
+    Upward,
+    /// Mutual or transitive cycle between directories. Lethal.
+    #[serde(rename = "circular")]
+    Circular,
+}
+
 /// Whether a discovered module is a file or directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModuleType {
@@ -64,6 +84,23 @@ pub struct Snapshot {
 #[cfg(test)]
 mod tests {
     use serde_json;
+
+    #[test]
+    fn dependency_direction_serde_roundtrip() {
+        use super::DependencyDirection;
+        let variants = [
+            (DependencyDirection::Downward, "\"downward\""),
+            (DependencyDirection::Sibling, "\"sibling\""),
+            (DependencyDirection::Upward, "\"upward\""),
+            (DependencyDirection::Circular, "\"circular\""),
+        ];
+        for (variant, expected_json) in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            assert_eq!(&json, expected_json);
+            let deserialized: DependencyDirection = serde_json::from_str(&json).unwrap();
+            assert_eq!(&deserialized, variant);
+        }
+    }
 
     #[test]
     fn module_type_serializes_to_string() {

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -230,6 +230,7 @@ mod tests {
             depth: 1,
             weight: 1,
             severity: 0.5,
+            direction: crate::core::DependencyDirection::Sibling,
             is_circular: false,
             cycle_path: Vec::new(),
             cycle_hop_files: Vec::new(),

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -1045,6 +1045,7 @@ mod tests {
                 to_module: "src/storage/mod.rs".to_string(),
                 depth: 1,
                 severity: 0.5,
+                direction: crate::core::DependencyDirection::Sibling,
                 is_circular: false,
                 cycle_path: Vec::new(),
                 cycle_hop_files: Vec::new(),

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1254,6 +1254,7 @@ mod tests {
             to_module: to.to_string(),
             depth,
             severity,
+            direction: crate::core::DependencyDirection::Sibling,
             is_circular: false,
             cycle_path: Vec::new(),
             cycle_hop_files: Vec::new(),

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -78,6 +78,7 @@ pub struct JsonHopFile {
 pub struct JsonCouplingViolation {
     pub severity: f64,
     pub weight: usize,
+    pub direction: String,
     pub from_module: String,
     pub to_module: String,
     pub dir_a: String,
@@ -178,6 +179,7 @@ impl JsonReport {
             .map(|v| JsonCouplingViolation {
                 severity: v.severity,
                 weight: v.weight,
+                direction: format!("{:?}", v.direction).to_lowercase(),
                 from_module: v.from_module.clone(),
                 to_module: v.to_module.clone(),
                 dir_a: v.dir_a.clone(),

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -32,10 +32,55 @@ pub struct Settings {
     /// Monorepo modules. Each gets independent analysis. If empty, whole project is one module.
     #[serde(default)]
     pub modules: Vec<ModuleConfig>,
+    /// Severity weights per dependency direction for RRI calculation.
+    #[serde(default = "default_risk_weights")]
+    pub risk_weights: RiskWeights,
 }
 
 fn default_allow_inline_suppression() -> bool {
     true
+}
+
+/// Severity weights per dependency direction for RRI (Relationship Risk Index).
+///
+/// RRI = weight × density. Higher weight = more architectural risk.
+/// See: Software Dependency Risk Framework (#167).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RiskWeights {
+    /// Parent imports child. Essential for layering, low risk.
+    #[serde(default = "default_weight_downward")]
+    pub downward: f64,
+    /// Same-level directories import each other. Moderate risk.
+    #[serde(default = "default_weight_sibling")]
+    pub sibling: f64,
+    /// Child imports parent. Violates architectural flow, high risk.
+    #[serde(default = "default_weight_upward")]
+    pub upward: f64,
+    /// Circular dependency between directories. Lethal.
+    #[serde(default = "default_weight_circular")]
+    pub circular: f64,
+}
+
+fn default_risk_weights() -> RiskWeights {
+    RiskWeights {
+        downward: default_weight_downward(),
+        sibling: default_weight_sibling(),
+        upward: default_weight_upward(),
+        circular: default_weight_circular(),
+    }
+}
+
+fn default_weight_downward() -> f64 {
+    2.0
+}
+fn default_weight_sibling() -> f64 {
+    4.0
+}
+fn default_weight_upward() -> f64 {
+    6.0
+}
+fn default_weight_circular() -> f64 {
+    10.0
 }
 
 /// A module within a monorepo. Each module is analyzed independently.
@@ -184,6 +229,7 @@ impl Default for Settings {
             layers: Vec::new(),
             allow_inline_suppression: default_allow_inline_suppression(),
             modules: Vec::new(),
+            risk_weights: default_risk_weights(),
         }
     }
 }
@@ -325,5 +371,51 @@ mod tests {
         assert!(ignore_set.is_match("src/test/MyTest.kt"));
         assert!(ignore_set.is_match("vendor/lib/util.go"));
         assert!(!ignore_set.is_match("src/main/App.kt"));
+    }
+
+    #[test]
+    fn risk_weights_default_values() {
+        let settings = Settings::default();
+        assert_eq!(settings.risk_weights.downward, 2.0);
+        assert_eq!(settings.risk_weights.sibling, 4.0);
+        assert_eq!(settings.risk_weights.upward, 6.0);
+        assert_eq!(settings.risk_weights.circular, 10.0);
+    }
+
+    #[test]
+    fn risk_weights_configurable() {
+        let dir = tempfile::tempdir().unwrap();
+        let noupling_dir = dir.path().join(".noupling");
+        std::fs::create_dir_all(&noupling_dir).unwrap();
+        std::fs::write(
+            noupling_dir.join("settings.json"),
+            r#"{"risk_weights": {"circular": 15.0, "sibling": 3.0}}"#,
+        )
+        .unwrap();
+
+        let settings = Settings::load(dir.path()).unwrap();
+        assert_eq!(settings.risk_weights.circular, 15.0);
+        assert_eq!(settings.risk_weights.sibling, 3.0);
+        // Unset fields use defaults
+        assert_eq!(settings.risk_weights.downward, 2.0);
+        assert_eq!(settings.risk_weights.upward, 6.0);
+    }
+
+    #[test]
+    fn old_settings_without_risk_weights_get_defaults() {
+        let dir = tempfile::tempdir().unwrap();
+        let noupling_dir = dir.path().join(".noupling");
+        std::fs::create_dir_all(&noupling_dir).unwrap();
+        std::fs::write(
+            noupling_dir.join("settings.json"),
+            r#"{"thresholds": {"score_green": 90.0}}"#,
+        )
+        .unwrap();
+
+        let settings = Settings::load(dir.path()).unwrap();
+        assert_eq!(settings.risk_weights.downward, 2.0);
+        assert_eq!(settings.risk_weights.sibling, 4.0);
+        assert_eq!(settings.risk_weights.upward, 6.0);
+        assert_eq!(settings.risk_weights.circular, 10.0);
     }
 }


### PR DESCRIPTION
## Summary
- Add `DependencyDirection` enum (`Downward`, `Sibling`, `Upward`, `Circular`) to `src/core/mod.rs`
- Add `direction` field to `CouplingViolation` — classified at creation time
- All sibling-pair coupling violations → `Sibling`, all circular → `Circular`
- `Downward`/`Upward` defined but unused until Phase 2 adds detection
- Foundation for #167 (Software Dependency Risk Framework)

## Test plan
- [x] Enum serde roundtrip test (all 4 variants)
- [x] Sibling violations get `Sibling` direction
- [x] Circular violations get `Circular` direction
- [x] All 188 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)