### PR TITLE
feat: TRI + RRI-based health score (#170)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -70,6 +70,8 @@ pub struct AuditResult {
     pub violations: Vec<CouplingViolation>,
     /// Overall health score (0-100). Higher is better.
     pub score: f64,
+    /// Total Risk Index: sum of all violation RRIs. Lower is better.
+    pub tri: f64,
     /// Total number of source modules analyzed.
     pub total_modules: usize,
     /// Per-module fan-in/fan-out metrics, sorted by fan_in descending.
@@ -336,6 +338,23 @@ impl AuditResult {
             };
             v.rri = direction_weight * v.weight.max(1) as f64;
         }
+
+        // Compute TRI (Total Risk Index) and derive health score.
+        // TRI = sum of all violation RRIs.
+        // Score = 100 * (1 - TRI / (total_modules * max_weight)), clamped to 0-100.
+        // max_weight is the highest configured weight (typically circular=10),
+        // so a project where every module averages 1 worst-case violation scores 0.
+        self.tri = self.violations.iter().map(|v| v.rri).sum();
+        let max_weight = weights
+            .downward
+            .max(weights.sibling)
+            .max(weights.upward)
+            .max(weights.circular);
+        self.score = if self.total_modules > 0 && max_weight > 0.0 {
+            (100.0 * (1.0 - self.tri / (self.total_modules as f64 * max_weight))).clamp(0.0, 100.0)
+        } else {
+            100.0
+        };
     }
 
     pub fn recalculate_score(&mut self) {
@@ -816,6 +835,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         return AuditResult {
             violations: Vec::new(),
             score: 100.0,
+            tri: 0.0,
             total_modules: 0,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1306,6 +1326,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
     AuditResult {
         violations,
         score,
+        tri: 0.0,
         total_modules,
         hotspots,
         rule_violations: Vec::new(),
@@ -2053,6 +2074,33 @@ mod tests {
         assert!(
             circular[0].rri >= 10.0,
             "Circular RRI should be at least 10"
+        );
+    }
+
+    #[test]
+    fn tri_computed_from_rri_sum() {
+        let modules = vec![
+            make_module("a", "src/alpha/mod.rs"),
+            make_module("b", "src/beta/mod.rs"),
+        ];
+        let deps = vec![make_dep("a", "b", 1), make_dep("a", "b", 2)];
+        let mut result = audit(&modules, &deps);
+        let weights = crate::settings::RiskWeights {
+            downward: 2.0,
+            sibling: 4.0,
+            upward: 6.0,
+            circular: 10.0,
+        };
+        result.apply_risk_weights(&weights);
+
+        // Sibling violation with density 2: RRI = 4 × 2 = 8
+        // TRI = sum of all RRIs = 8
+        assert_eq!(result.tri, 8.0);
+        // Score = 100 * (1 - 8 / (2 * 10)) = 100 * (1 - 0.4) = 60
+        assert!(
+            (result.score - 60.0).abs() < 0.1,
+            "Score should be ~60, got {}",
+            result.score
         );
     }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -149,6 +149,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
             score: 50.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -172,6 +173,7 @@ mod tests {
         let mut same_result = AuditResult {
             violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
             score: 50.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -200,6 +202,7 @@ mod tests {
         let baseline_result = AuditResult {
             violations: vec![make_coupling("a.rs", "b.rs")],
             score: 75.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -223,6 +226,7 @@ mod tests {
                 make_coupling("x.rs", "y.rs"), // new
             ],
             score: 50.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -252,6 +256,7 @@ mod tests {
         let baseline_result = AuditResult {
             violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
             score: 50.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -272,6 +277,7 @@ mod tests {
         let mut current = AuditResult {
             violations: vec![make_coupling("a.rs", "b.rs")],
             score: 75.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -251,6 +251,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![make_violation("src/scanner", "src/core")],
             score: 75.0,
+            tri: 0.0,
             total_modules: 2,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -283,6 +284,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![make_violation("src/scanner", "src/core")],
             score: 75.0,
+            tri: 0.0,
             total_modules: 2,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -312,6 +314,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 1,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -944,6 +944,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 2,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -972,6 +973,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 95.5,
+            tri: 0.0,
             total_modules: 1,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1006,6 +1008,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 3,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1058,6 +1061,7 @@ mod tests {
                 weight: 0,
             }],
             score: 75.0,
+            tri: 0.0,
             total_modules: 2,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -28,6 +28,7 @@ pub struct JsonReport {
     pub generator: String,
     pub snapshot_id: String,
     pub score: f64,
+    pub tri: f64,
     pub total_modules: usize,
     pub total_xs: usize,
     pub max_depth: usize,
@@ -209,6 +210,7 @@ impl JsonReport {
             generator: VERSION.to_string(),
             snapshot_id: snapshot_id.to_string(),
             score: result.score,
+            tri: result.tri,
             total_modules: result.total_modules,
             total_xs: result.total_xs,
             max_depth: result.max_depth,
@@ -1278,6 +1280,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![make_violation("a.rs", "b.rs", 1.0, 0)],
             score: 50.0,
+            tri: 0.0,
             total_modules: 2,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1311,6 +1314,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 5,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1341,6 +1345,7 @@ mod tests {
                 make_violation("e.rs", "f.rs", 0.25, 2),
             ],
             score: 42.0,
+            tri: 0.0,
             total_modules: 6,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1365,6 +1370,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![make_violation("scanner/mod.rs", "storage/mod.rs", 0.5, 1)],
             score: 75.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1391,6 +1397,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 4,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1417,6 +1424,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 5,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1451,6 +1459,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![v],
             score: 50.0,
+            tri: 0.0,
             total_modules: 2,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),
@@ -1477,6 +1486,7 @@ mod tests {
         let result = AuditResult {
             violations: vec![],
             score: 100.0,
+            tri: 0.0,
             total_modules: 3,
             hotspots: Vec::new(),
             rule_violations: Vec::new(),


### PR DESCRIPTION
## Summary
- Add `tri: f64` (Total Risk Index) to `AuditResult` — sum of all violation RRIs
- Health score now derived from TRI: `score = 100 × (1 - TRI / (total_modules × max_weight))`
- Replaces old `severity-sum / total_modules` formula with direction-aware risk calculation
- TRI included in JSON report output

## Score formula
```
TRI = Σ RRI(violation)
score = 100 × (1 - TRI / (total_modules × max_configured_weight))
```

Example: 2 modules, 1 sibling violation with density 2 → RRI = 4×2 = 8 → TRI = 8 → score = 60

## Test plan
- [x] `tri_computed_from_rri_sum` — verifies TRI = 8, score = 60 for known inputs
- [x] All 194 tests pass
- [x] Clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)