### PR TITLE
feat: architectural red flags — Fused Sibling + Trapped Child (#172)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -101,6 +101,30 @@ pub struct AuditResult {
     pub suppressed_count: usize,
     /// Modules with disproportionately high aggregate RRI — architectural "God Objects".
     pub gravity_wells: Vec<GravityWell>,
+    /// Architectural red flags detected from the dependency analysis.
+    pub red_flags: Vec<RedFlag>,
+}
+
+/// An architectural anti-pattern detected from the dependency analysis.
+#[derive(Debug, Clone)]
+pub struct RedFlag {
+    /// The type of anti-pattern.
+    pub flag_type: RedFlagType,
+    /// Modules involved (file paths or directory paths).
+    pub modules: Vec<String>,
+    /// The RRI that triggered this flag.
+    pub rri: f64,
+    /// Actionable recommendation to fix the issue.
+    pub recommendation: String,
+}
+
+/// Types of architectural red flags.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RedFlagType {
+    /// Two sibling modules with density higher than 2× the median sibling density.
+    FusedSibling,
+    /// A module with upward dependencies (child imports parent).
+    TrappedChild,
 }
 
 /// A module with disproportionately high aggregate RRI across multiple
@@ -380,6 +404,7 @@ impl AuditResult {
 
         // Detect Gravity Wells: modules with disproportionately high aggregate RRI.
         self.gravity_wells = compute_gravity_wells(&self.violations, &self.coupling_metrics);
+        self.red_flags = compute_red_flags(&self.violations, &self.coupling_metrics);
     }
 
     pub fn recalculate_score(&mut self) {
@@ -472,6 +497,66 @@ fn compute_gravity_wells(
 
     wells.sort_by(|a, b| b.total_rri.partial_cmp(&a.total_rri).unwrap());
     wells
+}
+
+/// Detect architectural red flags from violation data.
+fn compute_red_flags(
+    violations: &[CouplingViolation],
+    coupling_metrics: &[CouplingViolation],
+) -> Vec<RedFlag> {
+    let mut flags = Vec::new();
+
+    // Fused Sibling: sibling pairs with density > 2× median.
+    let all_siblings: Vec<&CouplingViolation> = violations
+        .iter()
+        .chain(coupling_metrics.iter())
+        .filter(|v| v.direction == DependencyDirection::Sibling)
+        .collect();
+
+    if all_siblings.len() >= 2 {
+        let mut densities: Vec<usize> = all_siblings.iter().map(|v| v.weight.max(1)).collect();
+        densities.sort();
+        let median_density = densities[densities.len() / 2] as f64;
+        let threshold = (median_density * 2.0).max(2.0);
+
+        for v in &all_siblings {
+            if v.weight as f64 > threshold {
+                flags.push(RedFlag {
+                    flag_type: RedFlagType::FusedSibling,
+                    modules: vec![v.from_module.clone(), v.to_module.clone()],
+                    rri: v.rri,
+                    recommendation: format!(
+                        "{} and {} have {} imports between them (median: {:.0}). \
+                         Consider merging them or extracting a shared abstraction.",
+                        v.dir_a, v.dir_b, v.weight, median_density
+                    ),
+                });
+            }
+        }
+    }
+
+    // Trapped Child: any module with upward dependencies.
+    let upward: Vec<&CouplingViolation> = violations
+        .iter()
+        .chain(coupling_metrics.iter())
+        .filter(|v| v.direction == DependencyDirection::Upward)
+        .collect();
+
+    for v in &upward {
+        flags.push(RedFlag {
+            flag_type: RedFlagType::TrappedChild,
+            modules: vec![v.from_module.clone(), v.to_module.clone()],
+            rri: v.rri,
+            recommendation: format!(
+                "{} imports from parent {}. This module cannot be reused \
+                 without its parent. Invert the dependency or use an interface.",
+                v.from_module, v.to_module
+            ),
+        });
+    }
+
+    flags.sort_by(|a, b| b.rri.partial_cmp(&a.rri).unwrap());
+    flags
 }
 
 /// Derive virtual directory tree from module file paths.
@@ -957,6 +1042,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
     }
 
@@ -1449,6 +1535,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         coupling_metrics: Vec::new(),
         suppressed_count: 0,
         gravity_wells: Vec::new(),
+        red_flags: Vec::new(),
     }
 }
 

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -164,6 +164,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         // Save baseline
@@ -189,6 +190,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
         assert_eq!(new, 0);
@@ -219,6 +221,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
 
@@ -244,6 +247,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 1);
@@ -275,6 +279,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
 
@@ -297,6 +302,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 0);

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -266,6 +266,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let mermaid = format_mermaid(&modules, &result);
@@ -300,6 +301,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let dot = format_dot(&modules, &result);
@@ -331,6 +333,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let mermaid = format_mermaid(&modules, &result);

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -959,6 +959,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -989,6 +990,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -1025,6 +1027,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -1079,6 +1082,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -41,7 +41,16 @@ pub struct JsonReport {
     pub coupling_violations: Vec<JsonCouplingViolation>,
     pub hotspots: Vec<JsonHotspot>,
     pub gravity_wells: Vec<JsonGravityWell>,
+    pub red_flags: Vec<JsonRedFlag>,
     pub directory_tree: Vec<JsonDirectory>,
+}
+
+#[derive(Serialize)]
+pub struct JsonRedFlag {
+    pub flag_type: String,
+    pub modules: Vec<String>,
+    pub rri: f64,
+    pub recommendation: String,
 }
 
 #[derive(Serialize)]
@@ -258,6 +267,16 @@ impl JsonReport {
                         upward: g.upward_rri,
                         circular: g.circular_rri,
                     },
+                })
+                .collect(),
+            red_flags: result
+                .red_flags
+                .iter()
+                .map(|f| JsonRedFlag {
+                    flag_type: format!("{:?}", f.flag_type),
+                    modules: f.modules.clone(),
+                    rri: f.rri,
+                    recommendation: f.recommendation.clone(),
                 })
                 .collect(),
             directory_tree,
@@ -1329,6 +1348,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-1");
@@ -1364,6 +1384,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-2");
@@ -1396,6 +1417,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-3");
@@ -1422,6 +1444,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let text = format_text(&result);
@@ -1450,6 +1473,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let text = format_text(&result);
@@ -1478,6 +1502,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-1");
@@ -1514,6 +1539,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-3");
@@ -1542,6 +1568,7 @@ mod tests {
             coupling_metrics: Vec::new(),
             suppressed_count: 0,
             gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-4");


### PR DESCRIPTION
## Summary
- Add `RedFlag` struct with `FusedSibling` and `TrappedChild` types
- **Fused Sibling**: detected when sibling pair density > 2× median sibling density — recommendation to merge or extract shared abstraction
- **Trapped Child**: detected for any upward dependency (ready for Phase 7 when upward detection lands)
- Computed in `apply_risk_weights()` alongside TRI
- Red flags included in JSON report with actionable recommendation text
- Sorted by RRI descending

## Test plan
- [x] All 194 tests pass
- [x] Clippy clean
- [x] Fused Sibling detector fires for high-density sibling pairs
- [x] Trapped Child detector ready (no upward deps exist yet)

🤖 Generated with [Claude Code](https://claude.com/claude-code)