### PR TITLE
feat: update all report formats with RRI/TRI (#173)

### DIFF
--- a/src/reporter/bundle.rs
+++ b/src/reporter/bundle.rs
@@ -61,6 +61,7 @@ pub fn generate_bundle_report(
         dep_count = dependencies.len(),
         violation_count = result.violations.len(),
         score = format!("{:.1}", result.score),
+        tri = format!("{:.0}", result.tri),
     );
 
     if let Some(parent) = output_path.parent() {

--- a/src/reporter/bundle_template.html
+++ b/src/reporter/bundle_template.html
@@ -73,7 +73,7 @@ footer {{ margin-top: 1.5rem; font-size: 0.65rem; color: #cbd5e1; }}
 <body>
 
 <h1><span>nou</span>pling</h1>
-<p class="subtitle">Health Score: <strong>{score}</strong>/100 &middot; Click to zoom in, click center to zoom out</p>
+<p class="subtitle">Health Score: <strong>{score}</strong>/100 &middot; TRI: <strong>{tri}</strong> &middot; Click to zoom in, click center to zoom out</p>
 
 <div class="controls">
     <label>Tension <input type="range" id="tension" min="0" max="100" value="85"> <span id="tension-val">0.85</span></label>

--- a/src/reporter/dashboard.rs
+++ b/src/reporter/dashboard.rs
@@ -8,6 +8,7 @@ use std::collections::{BTreeMap, HashMap};
 #[derive(Serialize)]
 pub struct DashboardData {
     pub score: f64,
+    pub tri: f64,
     pub total_modules: usize,
     pub total_violations: usize,
     pub total_xs: usize,
@@ -383,6 +384,7 @@ fn build_dashboard_data(
 
     DashboardData {
         score: dashboard_score,
+        tri: result.tri,
         total_modules: result.total_modules,
         total_violations: dashboard_violations,
         total_xs: dashboard_xs,

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -7,10 +7,15 @@ use crate::core::Module;
 use crate::reporter::VERSION;
 
 /// Build a directory-level dependency graph from modules and violations.
+struct EdgeInfo {
+    count: usize,
+    is_circular: bool,
+}
+
 fn build_dir_graph(
     modules: &[Module],
     result: &AuditResult,
-) -> (BTreeSet<String>, BTreeMap<(String, String), usize>) {
+) -> (BTreeSet<String>, BTreeMap<(String, String), EdgeInfo>) {
     // Collect all directories
     let mut dirs: BTreeSet<String> = BTreeSet::new();
     for module in modules {
@@ -23,19 +28,29 @@ fn build_dir_graph(
     }
 
     // Build edges from violations (both coupling and circular)
-    let mut edges: BTreeMap<(String, String), usize> = BTreeMap::new();
+    let mut edges: BTreeMap<(String, String), EdgeInfo> = BTreeMap::new();
     for v in &result.violations {
         if v.is_circular {
-            // Add edges for each hop in the cycle
             for i in 0..v.cycle_path.len().saturating_sub(1) {
                 let from = short_name(&v.cycle_path[i]);
                 let to = short_name(&v.cycle_path[i + 1]);
-                *edges.entry((from, to)).or_insert(0) += 1;
+                let entry = edges.entry((from, to)).or_insert(EdgeInfo {
+                    count: 0,
+                    is_circular: false,
+                });
+                entry.count += 1;
+                entry.is_circular = true;
             }
         } else {
             let from = short_name(&v.dir_a);
             let to = short_name(&v.dir_b);
-            *edges.entry((from, to)).or_insert(0) += 1;
+            edges
+                .entry((from, to))
+                .or_insert(EdgeInfo {
+                    count: 0,
+                    is_circular: false,
+                })
+                .count += 1;
         }
     }
 
@@ -104,16 +119,26 @@ pub fn format_mermaid(modules: &[Module], result: &AuditResult) -> String {
     out.push('\n');
 
     // Define edges
-    for ((from, to), count) in &edges {
-        if *count > 1 {
+    for ((from, to), info) in &edges {
+        let label = if info.count > 1 {
+            format!("|{}|", info.count)
+        } else {
+            String::new()
+        };
+        if info.is_circular {
             out.push_str(&format!(
-                "    {} -->|{}| {}\n",
+                "    {} -.->{} {}\n",
                 sanitize(from),
-                count,
+                label,
                 sanitize(to)
             ));
         } else {
-            out.push_str(&format!("    {} --> {}\n", sanitize(from), sanitize(to)));
+            out.push_str(&format!(
+                "    {} -->{} {}\n",
+                sanitize(from),
+                label,
+                sanitize(to)
+            ));
         }
     }
     out.push('\n');
@@ -168,16 +193,24 @@ pub fn format_dot(modules: &[Module], result: &AuditResult) -> String {
     out.push('\n');
 
     // Edges
-    for ((from, to), count) in &edges {
-        if *count > 1 {
+    for ((from, to), info) in &edges {
+        let mut attrs = Vec::new();
+        if info.count > 1 {
+            attrs.push(format!("label=\"{}\"", info.count));
+        }
+        if info.is_circular {
+            attrs.push("style=dashed".to_string());
+            attrs.push("color=\"#ef4444\"".to_string());
+        }
+        if attrs.is_empty() {
+            out.push_str(&format!("    {} -> {};\n", sanitize(from), sanitize(to)));
+        } else {
             out.push_str(&format!(
-                "    {} -> {} [label=\"{}\"];\n",
+                "    {} -> {} [{}];\n",
                 sanitize(from),
                 sanitize(to),
-                count
+                attrs.join(", ")
             ));
-        } else {
-            out.push_str(&format!("    {} -> {};\n", sanitize(from), sanitize(to)));
         }
     }
 

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -42,6 +42,7 @@ struct ReportData {
     total_score: f64,
     total_modules: usize,
     total_violations: usize,
+    total_tri: f64,
     total_xs: usize,
     score_green: f64,
     score_yellow: f64,
@@ -324,6 +325,7 @@ fn build_report_data(
         total_score: result.score,
         total_modules: result.total_modules,
         total_violations: result.violations.len(),
+        total_tri: result.tri,
         total_xs: result.total_xs,
         score_green: settings.thresholds.score_green,
         score_yellow: settings.thresholds.score_yellow,
@@ -478,10 +480,11 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 <div class=\"summary-card\" title=\"Overall project health, computed from all violations across the entire codebase. This is the canonical score reported by audit and used in CI gates.\"><div class=\"label\">Project Score <span class=\"info-icon\">&#9432;</span></div><div class=\"value\" style=\"color:{}\">{:.1}</div></div>
                 <div class=\"summary-card\"><div class=\"label\">Total Modules</div><div class=\"value\">{}</div></div>
                 <div class=\"summary-card\"><div class=\"label\">Total Violations</div><div class=\"value\">{}</div></div>
+                <div class=\"summary-card\" title=\"Total Risk Index: sum of all violation RRIs (Relationship Risk Index). Lower is better.\"><div class=\"label\">TRI <span class=\"info-icon\">&#9432;</span></div><div class=\"value\">{:.0}</div></div>
                 <div class=\"summary-card\" title=\"Total Excess: imports that need to be removed across all violations to reach a clean state.\"><div class=\"label\">Total XS <span class=\"info-icon\">&#9432;</span></div><div class=\"value\">{}</div></div>
             </div>
             <p class=\"score-hint\">The <strong>Project Score</strong> above is the overall codebase health. The <strong>Health Score</strong> in the cards below reflects only this directory &mdash; a directory can be 100/100 while the project score is lower because violations live in subdirectories.</p>",
-            banner_clr, data.total_score, data.total_modules, data.total_violations, data.total_xs
+            banner_clr, data.total_score, data.total_modules, data.total_violations, data.total_tri, data.total_xs
         )
     } else {
         String::new()

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -466,8 +466,8 @@ pub fn format_xml(modules: &[Module], result: &AuditResult, snapshot_id: &str) -
     let mut xml = String::new();
     xml.push_str("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
     xml.push_str(&format!(
-        "<noupling-report generator=\"{}\" snapshot=\"{}\" score=\"{:.2}\" totalModules=\"{}\" totalXs=\"{}\" maxDepth=\"{}\" suppressedCount=\"{}\" violationAgeNew=\"{}\" violationAgeRecent=\"{}\" violationAgeChronic=\"{}\" criticalViolations=\"{}\" totalCircular=\"{}\" totalCoupling=\"{}\">\n",
-        xml_escape(VERSION), xml_escape(&report.snapshot_id), report.score, report.total_modules,
+        "<noupling-report generator=\"{}\" snapshot=\"{}\" score=\"{:.2}\" tri=\"{:.1}\" totalModules=\"{}\" totalXs=\"{}\" maxDepth=\"{}\" suppressedCount=\"{}\" violationAgeNew=\"{}\" violationAgeRecent=\"{}\" violationAgeChronic=\"{}\" criticalViolations=\"{}\" totalCircular=\"{}\" totalCoupling=\"{}\">\n",
+        xml_escape(VERSION), xml_escape(&report.snapshot_id), report.score, report.tri, report.total_modules,
         report.total_xs, report.max_depth, report.suppressed_count,
         report.violation_age.new_count, report.violation_age.recent_count, report.violation_age.chronic_count,
         report.critical_violations, report.total_circular, report.total_coupling,
@@ -530,8 +530,8 @@ pub fn format_xml(modules: &[Module], result: &AuditResult, snapshot_id: &str) -
         xml.push_str("  <coupling-violations>\n");
         for v in &report.coupling_violations {
             xml.push_str(&format!(
-                "    <violation severity=\"{:.2}\" depth=\"{}\" fromModule=\"{}\" toModule=\"{}\" dirA=\"{}\" dirB=\"{}\"/>\n",
-                v.severity, v.depth, xml_escape(&v.from_module), xml_escape(&v.to_module),
+                "    <violation severity=\"{:.2}\" rri=\"{:.1}\" direction=\"{}\" depth=\"{}\" fromModule=\"{}\" toModule=\"{}\" dirA=\"{}\" dirB=\"{}\"/>\n",
+                v.severity, v.rri, xml_escape(&v.direction), v.depth, xml_escape(&v.from_module), xml_escape(&v.to_module),
                 xml_escape(&v.dir_a), xml_escape(&v.dir_b),
             ));
         }
@@ -555,6 +555,32 @@ pub fn format_xml(modules: &[Module], result: &AuditResult, snapshot_id: &str) -
         xml.push_str("    </directory>\n");
     }
     xml.push_str("  </directory-tree>\n");
+
+    // Gravity wells
+    if !report.gravity_wells.is_empty() {
+        xml.push_str("  <gravity-wells>\n");
+        for g in &report.gravity_wells {
+            xml.push_str(&format!(
+                "    <well module=\"{}\" totalRri=\"{:.1}\" relationships=\"{}\" directions=\"{}\"/>\n",
+                xml_escape(&g.module_path), g.total_rri, g.relationship_count, g.direction_count,
+            ));
+        }
+        xml.push_str("  </gravity-wells>\n");
+    }
+
+    // Red flags
+    if !report.red_flags.is_empty() {
+        xml.push_str("  <red-flags>\n");
+        for f in &report.red_flags {
+            xml.push_str(&format!(
+                "    <flag type=\"{}\" rri=\"{:.1}\">{}</flag>\n",
+                xml_escape(&f.flag_type),
+                f.rri,
+                xml_escape(&f.recommendation),
+            ));
+        }
+        xml.push_str("  </red-flags>\n");
+    }
 
     xml.push_str("</noupling-report>\n");
     xml
@@ -634,12 +660,22 @@ pub fn format_sonar(result: &AuditResult) -> String {
             }
             issues.push(issue);
         } else {
-            let (sonar_severity, effort) = if v.severity >= 0.5 {
-                ("CRITICAL", 20)
-            } else if v.severity >= 0.2 {
-                ("MAJOR", 10)
+            // Map RRI to Sonar severity (fall back to old severity if RRI is 0)
+            let risk = if v.rri > 0.0 {
+                v.rri
             } else {
-                ("MINOR", 5)
+                v.severity * 10.0
+            };
+            let (sonar_severity, effort) = if risk >= 160.0 {
+                ("BLOCKER", 60)
+            } else if risk >= 80.0 {
+                ("CRITICAL", 30)
+            } else if risk >= 40.0 {
+                ("MAJOR", 20)
+            } else if risk >= 10.0 {
+                ("MINOR", 10)
+            } else {
+                ("INFO", 5)
             };
 
             let dir_a_short = std::path::Path::new(&v.dir_a)
@@ -682,6 +718,9 @@ pub fn format_text(result: &AuditResult) -> String {
     let mut output = String::new();
 
     output.push_str(&format!("Health Score: {:.1}/100\n", result.score));
+    if result.tri > 0.0 {
+        output.push_str(&format!("Total Risk Index (TRI): {:.1}\n", result.tri));
+    }
     output.push_str(&format!("Total Modules: {}\n", result.total_modules));
     output.push_str(&format!("Violations: {}\n", result.violations.len()));
     if result.total_xs > 0 {
@@ -727,7 +766,18 @@ pub fn format_text(result: &AuditResult) -> String {
     if !result.violations.is_empty() {
         output.push('\n');
         for v in &result.violations {
-            let label = if v.is_circular {
+            let dir_label = match v.direction {
+                crate::core::DependencyDirection::Downward => "\u{2193}",
+                crate::core::DependencyDirection::Sibling => "\u{2194}",
+                crate::core::DependencyDirection::Upward => "\u{2191}",
+                crate::core::DependencyDirection::Circular => "\u{21bb}",
+            };
+            let rri_label = if v.rri > 0.0 {
+                format!(" RRI:{:.0}", v.rri)
+            } else {
+                String::new()
+            };
+            let weight_label = if v.is_circular {
                 " CIRCULAR".to_string()
             } else if v.weight > 1 {
                 format!(" x{}", v.weight)
@@ -735,8 +785,8 @@ pub fn format_text(result: &AuditResult) -> String {
                 String::new()
             };
             output.push_str(&format!(
-                "  [{:.2}]{} {} -> {} (depth {})\n",
-                v.severity, label, v.from_module, v.to_module, v.depth
+                "  [{:.2}]{}{} {} {} -> {} (depth {})\n",
+                v.severity, weight_label, rri_label, dir_label, v.from_module, v.to_module, v.depth
             ));
             output.push_str(&format!("         {} <> {}\n", v.dir_a, v.dir_b));
             if let Some(ref wl) = v.weakest_link {
@@ -894,6 +944,32 @@ pub fn format_text(result: &AuditResult) -> String {
         ));
     }
 
+    // Gravity Wells
+    if !result.gravity_wells.is_empty() {
+        output.push_str(&format!(
+            "\nGravity Wells ({}):\n",
+            result.gravity_wells.len()
+        ));
+        for g in result.gravity_wells.iter().take(10) {
+            output.push_str(&format!(
+                "  [RRI:{:.0}] {} ({} relationships)\n",
+                g.total_rri, g.module_path, g.relationship_count
+            ));
+        }
+    }
+
+    // Red Flags
+    if !result.red_flags.is_empty() {
+        output.push_str(&format!("\nRed Flags ({}):\n", result.red_flags.len()));
+        for f in result.red_flags.iter().take(10) {
+            let flag_icon = match f.flag_type {
+                crate::analyzer::RedFlagType::FusedSibling => "\u{26a0}",
+                crate::analyzer::RedFlagType::TrappedChild => "\u{26d4}",
+            };
+            output.push_str(&format!("  {} {}\n", flag_icon, f.recommendation));
+        }
+    }
+
     output.push_str(&format!("\n{}\n", VERSION));
 
     output
@@ -965,6 +1041,9 @@ pub fn format_pr(
             })
             .unwrap_or_default()
     ));
+    if result.tri > 0.0 {
+        out.push_str(&format!("| Total Risk Index | {:.1} |\n", result.tri));
+    }
     out.push_str(&format!("| Total XS | {} imports |\n", result.total_xs));
     if let Some(n) = new_violations {
         out.push_str(&format!("| New violations | {} |\n", n));
@@ -992,6 +1071,17 @@ pub fn format_pr(
         }
     } else {
         out.push_str("### Action items\n\nNo violations to fix \u{1f389}\n\n");
+    }
+
+    if !result.red_flags.is_empty() {
+        out.push_str(&format!("### Red Flags ({})\n\n", result.red_flags.len()));
+        for f in result.red_flags.iter().take(5) {
+            out.push_str(&format!(
+                "- **{:?}** (RRI: {:.0}) {}\n",
+                f.flag_type, f.rri, f.recommendation
+            ));
+        }
+        out.push('\n');
     }
 
     out.push_str(&format!("---\n_{}_\n", VERSION));
@@ -1037,6 +1127,9 @@ pub fn format_briefing(result: &AuditResult) -> String {
     let delta = projected_score - result.score;
 
     out.push_str(&format!("**Current score:** {:.1}/100  \n", result.score));
+    if result.tri > 0.0 {
+        out.push_str(&format!("**Total Risk Index:** {:.1}  \n", result.tri));
+    }
     if delta > 0.1 {
         out.push_str(&format!(
             "**If you fix the top 3 below, projected score:** {:.1} (+{:.1})\n\n",
@@ -1185,6 +1278,9 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
     md.push_str("| Metric | Value |\n");
     md.push_str("| :--- | :--- |\n");
     md.push_str(&format!("| Health Score | {:.1}/100 |\n", report.score));
+    if report.tri > 0.0 {
+        md.push_str(&format!("| Total Risk Index (TRI) | {:.1} |\n", report.tri));
+    }
     md.push_str(&format!("| Total Modules | {} |\n", report.total_modules));
     md.push_str(&format!(
         "| Critical Violations | {} |\n",
@@ -1253,8 +1349,8 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
     // Coupling violations
     if !report.coupling_violations.is_empty() {
         md.push_str("## Coupling Violations\n\n");
-        md.push_str("| Severity | From | To | Dir A | Dir B | Depth |\n");
-        md.push_str("| :--- | :--- | :--- | :--- | :--- | :--- |\n");
+        md.push_str("| Severity | RRI | Direction | From | To | Dir A | Dir B | Depth |\n");
+        md.push_str("| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |\n");
         for v in &report.coupling_violations {
             let from_short = std::path::Path::new(&v.from_module)
                 .file_name()
@@ -1273,8 +1369,15 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
                 .and_then(|f| f.to_str())
                 .unwrap_or(&v.dir_b);
             md.push_str(&format!(
-                "| {:.2} | `{}` | `{}` | {} | {} | {} |\n",
-                v.severity, from_short, to_short, dir_a_short, dir_b_short, v.depth
+                "| {:.2} | {:.0} | {} | `{}` | `{}` | {} | {} | {} |\n",
+                v.severity,
+                v.rri,
+                v.direction,
+                from_short,
+                to_short,
+                dir_a_short,
+                dir_b_short,
+                v.depth
             ));
         }
         md.push('\n');
@@ -1295,6 +1398,33 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
             dir.violations_count,
             dir.circular_count,
         ));
+    }
+
+    // Gravity wells
+    if !report.gravity_wells.is_empty() {
+        md.push_str("\n## Gravity Wells\n\n");
+        md.push_str("Modules with disproportionately high aggregate risk.\n\n");
+        md.push_str("| Module | Total RRI | Relationships | Directions |\n");
+        md.push_str("| :--- | :--- | :--- | :--- |\n");
+        for g in &report.gravity_wells {
+            md.push_str(&format!(
+                "| `{}` | {:.0} | {} | {} |\n",
+                g.module_path, g.total_rri, g.relationship_count, g.direction_count,
+            ));
+        }
+        md.push('\n');
+    }
+
+    // Red flags
+    if !report.red_flags.is_empty() {
+        md.push_str("\n## Red Flags\n\n");
+        for f in &report.red_flags {
+            md.push_str(&format!(
+                "- **{}** (RRI: {:.0}) {}\n",
+                f.flag_type, f.rri, f.recommendation,
+            ));
+        }
+        md.push('\n');
     }
 
     md


### PR DESCRIPTION
## Summary
Updates all 12 report formats to surface the new risk framework metrics:

| Format | Changes |
|--------|---------|
| **CLI text** | TRI in summary, direction arrows (↓↔↑↻) + RRI on violations, Gravity Wells + Red Flags sections |
| **JSON** | `tri`, `rri`, `direction` on violations, `gravity_wells`, `red_flags` arrays |
| **XML** | `tri` on root element, `rri`/`direction` on violations, `<gravity-wells>` + `<red-flags>` |
| **Sonar** | RRI-based severity: <10→INFO, <40→MINOR, <80→MAJOR, <160→CRITICAL, 160+→BLOCKER |
| **Markdown** | TRI in summary, RRI + direction columns on violations, Gravity Wells table, Red Flags |
| **HTML** | TRI metric card in project banner |
| **Bundle** | TRI in subtitle |
| **Dashboard** | TRI in data model |
| **PR** | TRI in summary table, Red Flags section |
| **Briefing** | TRI in header |
| **Mermaid** | Dashed edges for circular deps |
| **DOT** | Dashed red edges for circular deps |

## Test plan
- [x] All 195 tests pass
- [x] Clippy clean
- [x] Dev version installed locally for manual testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)