### PR TITLE
docs: update all documentation for Risk Framework + HTML report improvements

### DIFF
--- a/.agent/knowledge/project-map.md
+++ b/.agent/knowledge/project-map.md
@@ -22,9 +22,9 @@ Flat module structure in `src/`:
 | `core/` | Shared domain types: Module, ModuleType, Dependency, Snapshot |
 | `scanner/` | File discovery, Tree-sitter parsing (11 languages), import resolution |
 | `storage/` | SQLite persistence (snapshots, modules, dependencies) |
-| `analyzer/` | D_acc aggregation, BFS coupling audit, cycle detection |
-| `reporter/` | JSON, XML, Markdown, HTML, SonarCloud report generation |
-| `settings.rs` | Settings from .noupling/settings.json |
+| `analyzer/` | D_acc aggregation, BFS coupling audit, cycle detection, DependencyDirection classification, RRI/TRI computation, Gravity Well detection, Red Flag detection |
+| `reporter/` | JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Bundle, Dashboard, PR, Briefing, Strategy report generation |
+| `settings.rs` | Settings from .noupling/settings.json (includes risk_weights configuration) |
 | `diff.rs` | Git diff integration for PR/CI mode |
 
 ## Project Management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.6.0] - 2026-04-19
+
+### Added
+
+- **Software Dependency Risk Framework** (#167): Risk-weighted scoring replaces depth-based severity
+  - `DependencyDirection` classification: Downward (weight 2), Sibling (weight 4), Upward (weight 6), Circular (weight 10)
+  - RRI (Relationship Risk Index): direction_weight × density per violation
+  - TRI (Total Risk Index): sum of all violation RRIs, derives health score
+  - Configurable `risk_weights` in settings.json
+- **Gravity Well detection** (#171): Identifies "God Object" modules with disproportionately high aggregate RRI
+- **Architectural Red Flags** (#172): Fused Sibling (high-density sibling pairs) and Trapped Child (upward dependency) detection
+- **Per-level cycle visualization** in bundle sunburst: cycle participants turn red, weakest hop highlighted with "break this side" tooltip
+- **N-cycle detection**: 3+ node cycles (A→B→C→A) now detected via DFS fallback when no mutual pairs exist in SCC
+- **Metrics Guide**: Expandable guide in HTML report and section in MD reports explaining all metrics
+- Direction badges (↓↔↑↻) and RRI values shown in all report formats
+- TRI metric in HTML project banner, bundle subtitle, PR summary, and briefing header
+- Gravity Wells and Red Flags sections in CLI, JSON, XML, MD, and HTML reports
+- RRI-based Sonar severity mapping (INFO/MINOR/MAJOR/CRITICAL/BLOCKER)
+- Dashed red edges for circular deps in Mermaid and DOT graphs
+
+### Changed
+
+- Default `coupling_mode` changed from "actionable" to "strict" — sibling coupling now affects the score by default
+- Health score formula: `100 × (1 - TRI / (total_modules × max_weight))` replaces old `100 × (1 - sum_severity / total_modules)`
+- `coupling_mode` can now be set at top level of settings.json (not just inside thresholds)
+
 ## [0.3.0] - 2026-04-15
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,11 +65,12 @@ src/
 ├── cli.rs           - Clap argument parsing
 ├── settings.rs      - Settings from .noupling/settings.json
 ├── diff.rs          - Git diff integration for PR/CI mode
+├── baseline.rs      - Baseline file management for incremental adoption
 ├── core/            - Shared domain types (Module, Dependency, Snapshot)
 ├── scanner/         - File discovery, Tree-sitter parsing, import resolution
 ├── storage/         - SQLite persistence and repository patterns
-├── analyzer/        - D_acc aggregation, BFS coupling audit, cycle detection
-└── reporter/        - JSON, XML, Markdown, HTML, and SonarCloud report generation
+├── analyzer/        - D_acc aggregation, BFS coupling audit, cycle detection, DependencyDirection classification, RRI/TRI computation, Gravity Well detection, Red Flag detection
+└── reporter/        - JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Bundle, Dashboard, PR, Briefing, Strategy report generation
 ```
 
 ## Adding a New Language Parser

--- a/README.md
+++ b/README.md
@@ -17,19 +17,19 @@
 
 Most linters check code style. **noupling checks architecture.**
 
-It scans your project, builds a dependency graph from actual import statements, and quantifies how coupled your modules are. It finds:
+It scans your project, builds a dependency graph from actual import statements, and quantifies how coupled your modules are using risk-weighted scoring (RRI/TRI). It finds:
 
 - **Coupling violations** - sibling modules that depend on each other, breaking architectural boundaries
 - **Circular dependencies** - dependency chains that form loops (A -> B -> C -> A), preventing independent development and testing
 
-Every violation gets a **severity score** based on depth: problems at the root of your project hit harder than deep in a leaf package. The result is a single **health score (0-100)** you can track over time and gate in CI.
+Every violation gets a **risk score (RRI)** based on dependency direction and density: upward and circular dependencies carry higher risk weights than downward ones. The result is a single **health score (0-100)** you can track over time and gate in CI.
 
 ### Key Features
 
 - **14 languages**: C#, Dart, Go, Haskell, Java, JavaScript, Kotlin, PHP, Python, Ruby, Rust, Swift, TypeScript, Zig
 - **Tree-sitter parsing**: Fast, accurate AST-based import extraction (no regex)
 - **Parallel scanning**: Rayon-powered file discovery and parsing
-- **9 report formats**: JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Sunburst, Dashboard (or `all` to generate every format)
+- **12 report formats**: JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Sunburst, Dashboard, PR, Briefing, Strategy (or `all` to generate every format)
 - **Interactive HTML report**: Kover-style drill-down with color-coded scores
 - **Sunburst visualization**: Zoomable D3.js dependency graph with animated drill-down
 - **Technical Leader Dashboard**: Single-page executive view with all metrics, sortable scorecard, risk matrix
@@ -40,6 +40,10 @@ Every violation gets a **severity score** based on depth: problems at the root o
 - **Advanced metrics**: Module independence, blast radius, instability (Martin's I), dependency depth, violation age
 - **Per-module trends**: `--by-module` flag to track score evolution per directory across snapshots
 - **PR/CI mode**: `--diff-base main` to only flag new violations
+- **Risk-weighted scoring (RRI/TRI)**: Quantify coupling risk by dependency direction and density
+- **Gravity Well detection**: Identify modules that attract excessive inbound dependencies
+- **Red Flags (Fused Sibling, Trapped Child)**: Detect structural anti-patterns in module relationships
+- **Configurable risk weights per dependency direction**: Tune scoring to match your architecture's priorities
 - **Configurable**: Thresholds, layers, dependency rules, glob ignore patterns
 
 <p align="center">
@@ -207,7 +211,14 @@ Settings are stored in `.noupling/settings.json` (auto-created on first run):
     "go", "hs", "js", "jsx", "kts", "tsx", "zig",
     "dart", "php", "rb"
   ],
-  "allow_inline_suppression": true
+  "allow_inline_suppression": true,
+  "risk_weights": {
+    "downward": 2,
+    "sibling": 4,
+    "upward": 6,
+    "circular": 10
+  },
+  "coupling_mode": "strict"
 }
 ```
 
@@ -220,6 +231,8 @@ Settings are stored in `.noupling/settings.json` (auto-created on first run):
 | `ignore_patterns` | Glob patterns for dirs/files to skip | 15 defaults |
 | `source_extensions` | File types to scan | 17 extensions |
 | `allow_inline_suppression` | Enable `noupling:ignore` comments | true |
+| `risk_weights` | Risk weights per dependency direction (downward, sibling, upward, circular) | 2, 4, 6, 10 |
+| `coupling_mode` | Coupling analysis mode (`strict` or `relaxed`) | `strict` |
 
 ### Architectural Layers
 
@@ -285,11 +298,17 @@ Works with `//`, `#`, and `--` comment styles. Disable with `"allow_inline_suppr
    - **D_acc**: For each directory, compute the union of all external dependencies from its subtree
    - **BFS**: Walk the tree top-down, checking sibling pairs for coupling
    - **Cycles**: Find circular dependencies among siblings at each level
-4. **Score**: `Health = 100 * (1 - sum_severity / total_modules)`
+4. **Score**: Each dependency is classified by direction and assigned a risk weight:
+   - **Downward** (weight 2) - following the intended layer direction
+   - **Sibling** (weight 4) - coupling between peer modules
+   - **Upward** (weight 6) - violating the layer direction
+   - **Circular** (weight 10) - part of a dependency cycle
 
-Coupling severity: `1 / (depth + 1)` - root-level coupling is severe, deep coupling is mild.
+   **RRI** (Relationship Risk Index) = `direction_weight × density` (number of imports)
 
-Circular severity: `modules / (depth + 1) / 10` - always significant, amplified near the root.
+   **TRI** (Total Risk Index) = sum of all RRIs
+
+   **Health Score** = `100 × (1 - TRI / (total_modules × max_weight))`
 
 See [docs/architecture.md](docs/architecture.md) for the full technical details.
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -11,22 +11,22 @@ scan -> store -> analyze -> report
 ## Data Flow
 
 ```
-1. SCAN          2. STORE           3. ANALYZE         4. REPORT
-+-----------+    +-----------+     +------------+     +-----------+
-| scanner/  | -> | storage/  | --> | analyzer/  | --> | reporter/ |
-|           |    |           |     |            |     |           |
-| discover  |    | SQLite DB |     | D_acc      |     | JSON      |
-| parse     |    | snapshots |     | BFS audit  |     | XML       |
-| resolve   |    | modules   |     | cycles     |     | Markdown  |
-|           |    | deps      |     | score      |     | HTML      |
-+-----------+    +-----------+     +------------+     | Sonar     |
-                                                      +-----------+
+1. SCAN          2. STORE           3. ANALYZE           4. REPORT
++-----------+    +-----------+     +--------------+     +-----------+
+| scanner/  | -> | storage/  | --> | analyzer/    | --> | reporter/ |
+|           |    |           |     |              |     |           |
+| discover  |    | SQLite DB |     | D_acc        |     | JSON      |
+| parse     |    | snapshots |     | BFS audit    |     | XML       |
+| resolve   |    | modules   |     | risk weights |     | Markdown  |
+|           |    | deps      |     | cycles       |     | HTML      |
++-----------+    +-----------+     | score        |     | Sonar     |
+                                   +--------------+     +-----------+
 ```
 
 ## Module Responsibilities
 
 ### `src/core/`
-Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `Snapshot`. These are the data structures that flow between stages.
+Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `Snapshot`, `DependencyDirection`. The `DependencyDirection` enum classifies each dependency as Downward, Sibling, Upward, or Circular, which determines its risk weight during analysis. These are the data structures that flow between stages.
 
 ### `src/scanner/`
 **Stage 1: Scan.** Discovers source files, parses them with Tree-sitter, and resolves import paths.
@@ -47,12 +47,15 @@ Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `
 
 - **D_acc (Accumulated Dependencies):** For each directory, computes the union of all external dependencies from its subtree. Internal dependencies (within the same directory) are excluded.
 - **BFS Coupling Detection:** Walks the directory tree top-down. At each level, checks sibling pairs: if D_acc(A) references a module inside B, that's a coupling violation.
-- **Circular Dependency Detection:** At each BFS level, builds a graph between siblings using D_acc and finds all elementary cycles via DFS.
-- **Severity:** Coupling = `1/(depth+1)`. Circular = `modules/(depth+1)/10`.
-- **Health Score:** `100 * (1 - sum_severity / total_modules)`.
+- **Dependency Direction Classification:** Each coupling violation is classified by `DependencyDirection` (Downward, Sibling, Upward, or Circular), which determines the risk weight applied during scoring.
+- **Circular Dependency Detection:** At each BFS level, builds a graph between siblings using D_acc and finds all strongly connected components via Tarjan's SCC algorithm (replaced DFS-based cycle detection).
+- **Severity (RRI):** Risk-Relative Impact. `RRI = direction_weight * density`, where `direction_weight` comes from the `DependencyDirection` classification and `density` captures coupling intensity.
+- **Health Score:** `100 * (1 - TRI / (total_modules * max_weight))`, where `TRI` (Total Risk Index) is the sum of all RRIs across the project.
+- **Gravity Wells:** Modules whose aggregate RRI exceeds 2x the median RRI. These are the modules that disproportionately concentrate coupling risk.
+- **Red Flags:** Specific anti-patterns detected during analysis. *Fused Sibling* identifies high-density sibling pairs that are tightly co-dependent. *Trapped Child* identifies modules with upward dependencies on their parent or ancestors.
 
 ### `src/reporter/`
-**Stage 4: Report.** Generates output in 6 formats.
+**Stage 4: Report.** Generates output in 6 formats. All formats now include risk-weighted metrics: RRI per violation, TRI for the project, direction badges (Downward/Sibling/Upward/Circular), Gravity Wells, and Red Flags.
 
 - `mod.rs` - JSON report (comprehensive with directory tree), XML, SonarCloud, and text format.
 - `html.rs` - Multi-file static HTML with Kover-style drill-down navigation.
@@ -62,7 +65,7 @@ Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `
 Clap argument parsing. Commands: `init`, `scan`, `audit`, `report`.
 
 ### `src/settings.rs`
-Loads `.noupling/settings.json` with thresholds, ignore patterns, and source extensions. Falls back to defaults if missing.
+Loads `.noupling/settings.json` with thresholds, ignore patterns, source extensions, and `risk_weights` configuration (per-direction weight overrides for Downward, Sibling, Upward, and Circular). Falls back to defaults if missing.
 
 ### `src/diff.rs`
 Git integration for PR/CI mode. Shells out to `git diff --name-only <base>...HEAD` to get changed files.
@@ -76,3 +79,5 @@ Git integration for PR/CI mode. Shells out to `git diff --name-only <base>...HEA
 3. **Circular detection at sibling level.** Cycles are detected per BFS level using D_acc, not on the raw file dependency graph. This shows cycles at the directory level where they're actionable.
 
 4. **Settings auto-created.** If `.noupling/settings.json` doesn't exist, it's created with defaults on any command. This avoids a mandatory init step.
+
+5. **Risk-weighted scoring over depth-based severity.** The original severity formula (`1/(depth+1)`) treated all couplings equally regardless of their architectural impact. The risk-weighted approach (RRI = direction_weight x density) assigns higher weights to more harmful dependency directions (e.g., Circular > Upward > Sibling > Downward), producing scores that better reflect actual architectural risk.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -30,6 +30,36 @@
       Not a commit log. A narrative of architectural decisions&mdash;what broke, what was built, and why each change exists.
     </p>
 
+    <!-- ── v0.6.0 ─────────────────────────────────────── -->
+    <article class="release">
+      <h2>v0.6.0 &mdash; The Risk Framework Release</h2>
+      <div class="date">April 2026</div>
+
+      <h3><span class="tag tag-feat">feat</span> Software Dependency Risk Framework (<a href="https://github.com/pererikbergman/noupling/issues/167">#167</a>)</h3>
+      <p><strong>The friction:</strong> All coupling violations were scored by depth alone. A sibling dependency at depth 2 scored the same whether it was a harmless utility import or a dangerous architectural shortcut. There was no way to distinguish the risk level of different dependency types.</p>
+      <p><strong>The implementation:</strong> Every dependency is now classified by direction: Downward (&darr; weight 2), Sibling (&harr; weight 4), Upward (&uarr; weight 6), Circular (&#8635; weight 10). The Relationship Risk Index (RRI) combines direction weight with density (import count). The Total Risk Index (TRI) sums all RRIs to derive the health score. Weights are configurable in <code>settings.json</code>.</p>
+      <p><strong>The ripple effect:</strong> Teams can now see <em>why</em> a dependency is risky, not just <em>that</em> it exists. The same import count between two modules produces RRI 8 for a sibling pair vs RRI 20 for an upward dependency. Refactoring priorities become self-evident.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Gravity Well detection (<a href="https://github.com/pererikbergman/noupling/issues/171">#171</a>)</h3>
+      <p>Modules with aggregate RRI exceeding 2&times; the project median are flagged as &ldquo;Gravity Wells&rdquo;&mdash;God Objects that pull the system into their orbit. Includes per-direction RRI breakdown to show which dependency types contribute most.</p>
+
+      <h3><span class="tag tag-feat">feat</span> Architectural Red Flags (<a href="https://github.com/pererikbergman/noupling/issues/172">#172</a>)</h3>
+      <p>Two anti-pattern detectors: <strong>Fused Sibling</strong> (sibling pair with density &gt; 2&times; median&mdash;should be merged or extracted) and <strong>Trapped Child</strong> (module with upward dependencies&mdash;cannot be reused independently).</p>
+
+      <h3><span class="tag tag-feat">feat</span> Per-level cycle visualization in bundle sunburst</h3>
+      <p>Cycle participants at the current zoom level turn red. The weakest hop (fewest imports) is highlighted with a &ldquo;break this side&rdquo; tooltip. Hovering a cycle edge dims everything else.</p>
+
+      <h3>Also in this release:</h3>
+      <ul>
+        <li><span class="tag tag-feat">feat</span> Default coupling mode changed to &ldquo;strict&rdquo;&mdash;sibling coupling now affects the score</li>
+        <li><span class="tag tag-feat">feat</span> Metrics Guide in HTML and Markdown reports</li>
+        <li><span class="tag tag-feat">feat</span> Direction badges (&darr;&harr;&uarr;&#8635;) and RRI values in all report formats</li>
+        <li><span class="tag tag-feat">feat</span> RRI-based Sonar severity mapping</li>
+        <li><span class="tag tag-feat">feat</span> Dashed red edges for circular deps in Mermaid/DOT</li>
+        <li><span class="tag tag-feat">feat</span> N-cycle detection (3+ node cycles)</li>
+      </ul>
+    </article>
+
     <!-- ── v0.5.0 ─────────────────────────────────────── -->
     <article class="release">
       <h2>v0.5.0 &mdash; The Tech Lead Release</h2>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -42,6 +42,8 @@
 
       <h4>Configuration</h4>
       <a href="#thresholds">Thresholds</a>
+      <a href="#risk-weights">Risk Weights</a>
+      <a href="#coupling-mode">Coupling Mode</a>
       <a href="#ignore-patterns">Ignore Patterns</a>
       <a href="#layers">Architectural Layers</a>
       <a href="#dependency-rules">Dependency Rules</a>
@@ -53,6 +55,12 @@
       <a href="#diff-mode">Diff Mode</a>
       <a href="#ci-integration">CI Integration</a>
       <a href="#report-formats">Report Formats</a>
+
+      <h4>Risk Framework</h4>
+      <a href="#rri">RRI (Risk Index)</a>
+      <a href="#tri">TRI (Total Risk)</a>
+      <a href="#gravity-wells">Gravity Wells</a>
+      <a href="#red-flags">Red Flags</a>
 
       <h4>Tech Lead Metrics</h4>
       <a href="#independence">Module Independence</a>
@@ -106,8 +114,10 @@ noupling audit . --fail-below 80</code></pre>
 
 
       <h2 id="health-score">Health Score</h2>
-      <p>The health score is a single number (0&ndash;100) that quantifies your architecture's coupling:</p>
-<pre><code>Score = 100 &times; (1 - sum_of_severities / total_modules)</code></pre>
+      <p>The health score is a single number (0&ndash;100) that quantifies your architecture's coupling risk:</p>
+<pre><code>Score = 100 &times; (1 - TRI / (total_modules &times; max_weight))</code></pre>
+
+      <p><strong>TRI</strong> (Total Risk Index) is the sum of all violation RRIs. Each violation's <strong>RRI</strong> (Relationship Risk Index) is computed as <code>direction_weight &times; density</code>, where <code>direction_weight</code> reflects the severity of the dependency direction and <code>density</code> captures how many imports exist between the pair. See <a href="#rri">RRI</a> and <a href="#tri">TRI</a> for details.</p>
 
       <table>
         <thead><tr><th>Range</th><th>Status</th><th>Action</th></tr></thead>
@@ -185,6 +195,49 @@ noupling hook uninstall [PATH]</code></pre>
   }
 }</code></pre>
       <p><code>minimum_severity</code> hides low-severity violations to reduce noise. <code>critical_severity</code> flags violations as critical in reports.</p>
+
+
+      <h2 id="risk-weights">Risk Weights</h2>
+      <p>Risk weights control how heavily each dependency direction contributes to the <a href="#rri">RRI</a> score. Configure in <code>.noupling/settings.json</code>:</p>
+<pre><code class="language-json">{
+  "risk_weights": {
+    "downward": 2,
+    "sibling": 4,
+    "upward": 6,
+    "circular": 10
+  }
+}</code></pre>
+      <table>
+        <thead><tr><th>Direction</th><th>Weight</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td>Downward</td><td>2</td><td>Dependency follows the declared layer order. Low risk, but still tracked.</td></tr>
+          <tr><td>Sibling</td><td>4</td><td>Dependency between modules at the same level. Creates horizontal coupling.</td></tr>
+          <tr><td>Upward</td><td>6</td><td>Dependency flows against the layer order. Inverts the architecture.</td></tr>
+          <tr><td>Circular</td><td>10</td><td>Part of a dependency cycle. Highest risk; prevents independent deployment.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <strong>Pro-Tip:</strong> Adjust weights to match your team's priorities. If upward dependencies are your biggest pain point, increase the upward weight to surface them more aggressively in the health score.
+      </div>
+
+
+      <h2 id="coupling-mode">Coupling Mode</h2>
+      <p>The <code>coupling_mode</code> setting controls which dependencies are treated as violations:</p>
+<pre><code class="language-json">{
+  "coupling_mode": "strict"
+}</code></pre>
+      <table>
+        <thead><tr><th>Mode</th><th>Behavior</th></tr></thead>
+        <tbody>
+          <tr><td><code>strict</code> (default)</td><td>All sibling coupling is a violation. Every cross-module dependency at the same level is flagged.</td></tr>
+          <tr><td><code>actionable</code></td><td>Only circular dependencies are violations. Sibling coupling is tracked but not penalized, reducing noise in projects where lateral dependencies are acceptable.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout-warn callout">
+        <strong>Guardrail:</strong> Start with <code>strict</code> mode on greenfield projects. Switch to <code>actionable</code> for legacy codebases where fixing all sibling coupling at once is impractical&mdash;focus on breaking cycles first.
+      </div>
 
 
       <h2 id="ignore-patterns">Ignore Patterns</h2>
@@ -318,6 +371,48 @@ noupling audit .</code></pre>
       </table>
 
 
+      <!-- Risk Framework -->
+      <h2 id="rri">RRI (Relationship Risk Index)</h2>
+      <p>Each violation is assigned an RRI score that reflects both the severity of the dependency direction and the density of imports between the pair:</p>
+<pre><code>RRI = direction_weight &times; density</code></pre>
+      <p><code>direction_weight</code> comes from the <a href="#risk-weights">risk weights</a> configuration (e.g., 4 for sibling, 10 for circular). <code>density</code> is the number of import statements between the two modules.</p>
+      <p>Higher RRI means higher architectural risk. A single circular dependency with 3 imports scores <code>10 &times; 3 = 30</code>, while a sibling coupling with 1 import scores only <code>4 &times; 1 = 4</code>.</p>
+
+
+      <h2 id="tri">TRI (Total Risk Index)</h2>
+      <p>The project-level risk metric, computed as the sum of all violation RRIs:</p>
+<pre><code>TRI = &sum; RRI<sub>i</sub>  (for all violations i)</code></pre>
+      <p>Lower is better. TRI feeds directly into the <a href="#health-score">health score</a> formula. Track TRI over time with <code>noupling trend</code> to ensure architectural risk is decreasing.</p>
+
+      <div class="callout">
+        <strong>Pro-Tip:</strong> TRI is additive, so you can compare modules directly: a module contributing 80% of the TRI is the obvious place to start refactoring.
+      </div>
+
+
+      <h2 id="gravity-wells">Gravity Wells</h2>
+      <p>A <strong>gravity well</strong> is a module whose total RRI exceeds 2&times; the median RRI across all modules. These are "God Objects" that pull the system into their orbit&mdash;everything depends on them, or they depend on everything.</p>
+      <p>Gravity wells are flagged in the audit output and highlighted in the dashboard. They represent the highest-leverage refactoring targets: reducing a gravity well's coupling has outsized impact on the overall health score.</p>
+
+      <div class="callout-warn callout">
+        <strong>Guardrail:</strong> A module can be a gravity well even with individually low-severity violations if it has many of them. Watch for modules that accumulate dozens of small couplings.
+      </div>
+
+
+      <h2 id="red-flags">Red Flags</h2>
+      <p>Red flags are specific anti-patterns detected by the risk framework:</p>
+      <table>
+        <thead><tr><th>Red Flag</th><th>Detection</th><th>Why it matters</th></tr></thead>
+        <tbody>
+          <tr><td><strong>Fused Sibling</strong></td><td>Sibling coupling density &gt; 2&times; median density</td><td>Two modules so tightly coupled they are effectively one. Consider merging them or extracting a shared abstraction.</td></tr>
+          <tr><td><strong>Trapped Child</strong></td><td>Module has upward dependencies (child depends on parent layer)</td><td>Inverts the dependency hierarchy. The "child" cannot be tested, deployed, or understood without its parent.</td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <strong>Pro-Tip:</strong> Red flags are intentionally opinionated. If a flagged pattern is correct for your architecture, suppress it with <a href="#inline-suppression">inline suppression</a> or adjust your <a href="#layers">layer definitions</a>.
+      </div>
+
+
       <!-- Tech Lead Metrics -->
       <h2 id="independence">Module Independence</h2>
       <p>For each top-level directory, the ratio of internal dependencies to total dependencies.</p>
@@ -374,9 +469,9 @@ noupling audit .</code></pre>
 
       <!-- Concepts -->
       <h2 id="coupling">Coupling Violations</h2>
-      <p>A coupling violation occurs when sibling directories depend on each other. Severity is depth-weighted:</p>
-<pre><code>severity = weight / (depth + 1)</code></pre>
-      <p>Root-level coupling (depth 0) is most severe. Multiple imports between the same pair are aggregated by weight.</p>
+      <p>A coupling violation occurs when sibling directories depend on each other. Each violation is scored using the <a href="#rri">RRI</a> (Relationship Risk Index), which replaces the earlier depth-based severity model:</p>
+<pre><code>RRI = direction_weight &times; density</code></pre>
+      <p>The <code>direction_weight</code> reflects the dependency direction (see <a href="#risk-weights">Risk Weights</a>) and <code>density</code> counts the import statements between the pair. Multiple imports between the same pair increase the RRI proportionally.</p>
 
       <div class="callout">
         <strong>Pro-Tip:</strong> Not all coupling is bad. Use <a href="#layers">Layers</a> to declare intended dependency directions so legitimate downward dependencies aren't flagged.
@@ -384,8 +479,8 @@ noupling audit .</code></pre>
 
 
       <h2 id="circular">Circular Dependencies</h2>
-      <p>A cycle exists when imports form a loop: A &rarr; B &rarr; C &rarr; A. Detected via DFS on sibling adjacency graphs built from D_acc (accumulated external dependencies).</p>
-<pre><code>severity = total_modules / (depth + 1) / 10</code></pre>
+      <p>A cycle exists when imports form a loop: A &rarr; B &rarr; C &rarr; A. Cycles are detected using <strong>Tarjan's SCC</strong> (Strongly Connected Components) algorithm to find all components, followed by <strong>mutual pair enumeration</strong> to surface the individual circular relationships within each SCC.</p>
+      <p>Each circular dependency receives the highest <a href="#risk-weights">risk weight</a> (default: 10) and its RRI scales with the density of imports in the cycle.</p>
       <p>Cycles are grouped by <strong>order</strong>: 2 (mutual), 3 (triangular), N. Each includes the weakest link and break cost via the <a href="#xs-metric">XS metric</a>.</p>
 
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -68,7 +68,7 @@
         <article class="feature-card">
           <span class="icon">&#128200;</span>
           <h3>One health score (0&ndash;100)</h3>
-          <p>Track architectural drift across snapshots. Gate CI with <code>--fail-below</code>. Drill into interactive HTML reports to see exactly where coupling lives.</p>
+          <p>A single, risk-weighted number that tracks architectural drift across snapshots. Gate CI with <code>--fail-below</code>. Drill into interactive HTML reports to see exactly where coupling lives.</p>
         </article>
         <article class="feature-card">
           <span class="icon">&#9889;</span>
@@ -78,11 +78,11 @@
         <article class="feature-card">
           <span class="icon">&#128736;</span>
           <h3>Configurable layers &amp; rules</h3>
-          <p>Define architectural layers so downward dependencies aren't flagged. Add custom rules to forbid specific import patterns. Suppress known violations inline.</p>
+          <p>Define architectural layers so downward dependencies aren't flagged. Add custom rules to forbid specific import patterns. Tune risk weights per dependency direction. Suppress known violations inline.</p>
         </article>
         <article class="feature-card">
           <span class="icon">&#128230;</span>
-          <h3>9 report formats</h3>
+          <h3>12 report formats</h3>
           <p>JSON, XML, Markdown, interactive HTML, SonarCloud, Mermaid, GraphViz DOT, zoomable Sunburst, and an executive Dashboard. Use <code>--format all</code> to generate every format in one command.</p>
         </article>
       </div>

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -510,7 +510,24 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 <div class=\"summary-card\" title=\"Total Risk Index: sum of all violation RRIs (Relationship Risk Index). Lower is better.\"><div class=\"label\">TRI <span class=\"info-icon\">&#9432;</span></div><div class=\"value\">{:.0}</div></div>
                 <div class=\"summary-card\" title=\"Total Excess: imports that need to be removed across all violations to reach a clean state.\"><div class=\"label\">Total XS <span class=\"info-icon\">&#9432;</span></div><div class=\"value\">{}</div></div>
             </div>
-            <p class=\"score-hint\">The <strong>Project Score</strong> above is the overall codebase health. The <strong>Health Score</strong> in the cards below reflects only this directory &mdash; a directory can be 100/100 while the project score is lower because violations live in subdirectories.</p>",
+            <p class=\"score-hint\">The <strong>Project Score</strong> above is the overall codebase health. The <strong>Health Score</strong> in the cards below reflects only this directory &mdash; a directory can be 100/100 while the project score is lower because violations live in subdirectories.</p>
+            <details class=\"metrics-guide\" style=\"margin-top:0.75rem;font-size:0.75rem;color:#475569\">
+                <summary style=\"cursor:pointer;font-weight:600;color:#334155\">Metrics Guide</summary>
+                <div style=\"margin-top:0.5rem;line-height:1.6\">
+                    <p><strong>Project Score</strong> (0&ndash;100) &mdash; overall codebase health derived from the Total Risk Index. Higher is better. Formula: <code>100 &times; (1 &minus; TRI / (modules &times; max_weight))</code></p>
+                    <p><strong>TRI</strong> (Total Risk Index) &mdash; sum of all violation RRIs. Lower is better. A TRI of 0 means no violations.</p>
+                    <p><strong>RRI</strong> (Relationship Risk Index) &mdash; risk score for a single violation. <code>RRI = direction_weight &times; density</code>, where density is the number of imports between the two modules.</p>
+                    <p><strong>Severity</strong> &mdash; legacy metric based on depth. Being replaced by RRI in future versions.</p>
+                    <p><strong>Total XS</strong> (Excess) &mdash; total import statements that need to be removed to fix all violations.</p>
+                    <p style=\"margin-top:0.5rem\"><strong>Direction types and weights:</strong></p>
+                    <table style=\"font-size:0.72rem;border-collapse:collapse;margin:0.25rem 0\">
+                        <tr><td style=\"padding:0.15rem 0.5rem\"><span style=\"color:#22c55e\">&darr;</span> <strong>Downward</strong></td><td style=\"padding:0.15rem 0.5rem\">Weight 2</td><td style=\"padding:0.15rem 0.5rem;color:#64748b\">Parent imports child. Normal architectural flow.</td></tr>
+                        <tr><td style=\"padding:0.15rem 0.5rem\"><span style=\"color:#eab308\">&harr;</span> <strong>Sibling</strong></td><td style=\"padding:0.15rem 0.5rem\">Weight 4</td><td style=\"padding:0.15rem 0.5rem;color:#64748b\">Same-level directories import each other. Signals missing shared abstraction.</td></tr>
+                        <tr><td style=\"padding:0.15rem 0.5rem\"><span style=\"color:#ef4444\">&uarr;</span> <strong>Upward</strong></td><td style=\"padding:0.15rem 0.5rem\">Weight 6</td><td style=\"padding:0.15rem 0.5rem;color:#64748b\">Child imports parent. Destroys module reusability.</td></tr>
+                        <tr><td style=\"padding:0.15rem 0.5rem\"><span style=\"color:#dc2626\">&#8635;</span> <strong>Circular</strong></td><td style=\"padding:0.15rem 0.5rem\">Weight 10</td><td style=\"padding:0.15rem 0.5rem;color:#64748b\">Mutual or transitive cycle. Breaks builds and makes testing impossible.</td></tr>
+                    </table>
+                </div>
+            </details>",
             banner_clr, data.total_score, data.total_modules, data.total_violations, data.total_tri, data.total_xs
         )
     } else {
@@ -580,6 +597,7 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
         }
 
         violations_html.push_str("<h2>Circular Dependencies</h2>\n");
+        violations_html.push_str("<p class=\"section-hint\">Modules that depend on each other in a loop. These have the highest risk weight (10) because they break build isolation and make unit testing impossible. The <strong>RRI</strong> column shows the total risk for each cycle.</p>\n");
         for (order, violations) in &by_order {
             let label = match order {
                 2 => "Mutual Dependencies (Order 2)".to_string(),
@@ -592,7 +610,7 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
                 violations.len()
             ));
             violations_html.push_str("<table class=\"violations\">\n");
-            violations_html.push_str("<tr><th>Severity</th><th>RRI</th><th>Cycle</th></tr>\n");
+            violations_html.push_str("<tr><th title=\"Legacy severity metric\">Severity</th><th title=\"Relationship Risk Index = direction_weight × density\">RRI</th><th>Cycle</th></tr>\n");
             for v in violations {
                 let sev_clr = "#ef4444";
                 // Render cycle inline
@@ -625,7 +643,7 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
 
         if !promoted.is_empty() {
             violations_html.push_str("<div class=\"violations-promoted\">\n");
-            violations_html.push_str("<p class=\"section-hint\">Top 5 violations by severity &mdash; tackle these first for the biggest score impact.</p>\n");
+            violations_html.push_str("<p class=\"section-hint\">Top 5 violations by severity &mdash; tackle these first for the biggest score impact. <strong>RRI</strong> = direction_weight &times; number_of_imports. <strong>Dir</strong> = dependency direction (&darr; downward, &harr; sibling, &uarr; upward, &#8635; circular).</p>\n");
             for v in &promoted {
                 let sev_clr = if v.severity >= data.critical_severity {
                     "#ef4444"
@@ -677,7 +695,7 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
             ));
             violations_html.push_str("<table class=\"violations\">\n");
             violations_html.push_str(
-                "<tr><th>Severity</th><th>RRI</th><th>Dir</th><th>From</th><th>To</th></tr>\n",
+                "<tr><th title=\"Legacy severity metric\">Severity</th><th title=\"Relationship Risk Index = direction_weight × number of imports\">RRI</th><th title=\"Dependency direction: ↓ downward, ↔ sibling, ↑ upward, ↻ circular\">Dir</th><th>From</th><th>To</th></tr>\n",
             );
             for v in &rest {
                 let sev_clr = if v.severity >= data.critical_severity {

--- a/src/reporter/md.rs
+++ b/src/reporter/md.rs
@@ -115,6 +115,9 @@ fn render_dir_page(
     md.push_str("| :--- | :--- |\n");
     if is_root {
         md.push_str(&format!("| Health Score | {:.1}/100 |\n", report.score));
+        if report.tri > 0.0 {
+            md.push_str(&format!("| Total Risk Index (TRI) | {:.1} |\n", report.tri));
+        }
     }
     md.push_str(&format!("| Modules | {} |\n", dir.module_count));
     md.push_str(&format!("| Violations | {} |\n", violations));
@@ -135,6 +138,19 @@ fn render_dir_page(
         md.push_str(&format!("| Suppressed | {} |\n", report.suppressed_count));
     }
     md.push('\n');
+
+    if is_root {
+        md.push_str("### Metrics Guide\n\n");
+        md.push_str("| Metric | Description |\n");
+        md.push_str("| :--- | :--- |\n");
+        md.push_str("| **Health Score** | Overall codebase health (0-100). `100 × (1 - TRI / (modules × max_weight))` |\n");
+        md.push_str(
+            "| **TRI** | Total Risk Index — sum of all violation RRIs. Lower is better |\n",
+        );
+        md.push_str("| **RRI** | Relationship Risk Index — per-violation risk. `direction_weight × imports` |\n");
+        md.push_str("| **Severity** | Legacy metric based on depth. Being replaced by RRI |\n\n");
+        md.push_str("**Direction types:** ↓ Downward (weight 2) · ↔ Sibling (weight 4) · ↑ Upward (weight 6) · ↻ Circular (weight 10)\n\n");
+    }
 
     // Contents: child directories
     if !dir.children.is_empty() || !dir.files.is_empty() {
@@ -179,7 +195,8 @@ fn render_dir_page(
                 by_order.entry(v.cycle_order).or_default().push(v);
             }
 
-            md.push_str("## Circular Dependencies\n");
+            md.push_str("## Circular Dependencies\n\n");
+            md.push_str("Modules that depend on each other in a loop (weight 10). Break the weakest link to resolve.\n");
             for (order, cycles) in &by_order {
                 let label = match order {
                     2 => "Mutual Dependencies (Order 2)".to_string(),
@@ -258,8 +275,9 @@ fn render_dir_page(
         // Coupling violations
         if !coupling.is_empty() {
             md.push_str("## Coupling Violations\n\n");
-            md.push_str("| Severity | From | To |\n");
-            md.push_str("| :--- | :--- | :--- |\n");
+            md.push_str("Sibling directories importing each other. **RRI** = direction weight × number of imports.\n\n");
+            md.push_str("| Severity | RRI | Dir | From | To |\n");
+            md.push_str("| :--- | :--- | :--- | :--- | :--- |\n");
             for v in &coupling {
                 let from_short = std::path::Path::new(&v.from_module)
                     .file_name()
@@ -269,9 +287,15 @@ fn render_dir_page(
                     .file_name()
                     .and_then(|f| f.to_str())
                     .unwrap_or(&v.to_module);
+                let dir_symbol = match v.direction {
+                    crate::core::DependencyDirection::Downward => "↓",
+                    crate::core::DependencyDirection::Sibling => "↔",
+                    crate::core::DependencyDirection::Upward => "↑",
+                    crate::core::DependencyDirection::Circular => "↻",
+                };
                 md.push_str(&format!(
-                    "| {:.2} | `{}` | `{}` |\n",
-                    v.severity, from_short, to_short
+                    "| {:.2} | {:.0} | {} | `{}` | `{}` |\n",
+                    v.severity, v.rri, dir_symbol, from_short, to_short
                 ));
             }
             md.push('\n');

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1295,9 +1295,27 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
         report.total_coupling
     ));
 
+    // Metrics guide
+    md.push_str("\n## Metrics Guide\n\n");
+    md.push_str("| Metric | Description |\n");
+    md.push_str("| :--- | :--- |\n");
+    md.push_str("| **Health Score** | Overall codebase health (0-100). Formula: `100 × (1 - TRI / (modules × max_weight))` |\n");
+    md.push_str("| **TRI** | Total Risk Index — sum of all violation RRIs. Lower is better |\n");
+    md.push_str("| **RRI** | Relationship Risk Index — risk for one violation. `direction_weight × number_of_imports` |\n");
+    md.push_str("| **Severity** | Legacy metric based on depth. Being replaced by RRI |\n");
+    md.push_str("| **Total XS** | Total imports to remove to fix all violations |\n\n");
+    md.push_str("**Direction types and weights:**\n\n");
+    md.push_str("| Symbol | Direction | Weight | Meaning |\n");
+    md.push_str("| :--- | :--- | :--- | :--- |\n");
+    md.push_str("| ↓ | Downward | 2 | Parent imports child — normal architectural flow |\n");
+    md.push_str("| ↔ | Sibling | 4 | Same-level directories import each other — missing shared abstraction |\n");
+    md.push_str("| ↑ | Upward | 6 | Child imports parent — destroys module reusability |\n");
+    md.push_str("| ↻ | Circular | 10 | Mutual or transitive cycle — breaks builds, makes testing impossible |\n");
+
     // Circular dependencies grouped by order
     if !report.circular_dependencies.is_empty() {
-        md.push_str("\n## Circular Dependencies\n");
+        md.push_str("\n## Circular Dependencies\n\n");
+        md.push_str("Modules that depend on each other in a loop. These have the highest risk weight (10) because they break build isolation and make unit testing impossible.\n");
         for (label, cycles) in &report.circular_dependencies {
             md.push_str(&format!("\n### {} ({} found)\n\n", label, cycles.len()));
             for (idx, cycle) in cycles.iter().enumerate() {
@@ -1349,6 +1367,7 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
     // Coupling violations
     if !report.coupling_violations.is_empty() {
         md.push_str("## Coupling Violations\n\n");
+        md.push_str("Sibling directories that import each other. Each violation's **RRI** (Relationship Risk Index) = direction weight × number of imports. **Direction** shows the dependency type (↓ downward, ↔ sibling, ↑ upward, ↻ circular).\n\n");
         md.push_str("| Severity | RRI | Direction | From | To | Dir A | Dir B | Depth |\n");
         md.push_str("| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |\n");
         for v in &report.coupling_violations {
@@ -1403,7 +1422,7 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
     // Gravity wells
     if !report.gravity_wells.is_empty() {
         md.push_str("\n## Gravity Wells\n\n");
-        md.push_str("Modules with disproportionately high aggregate risk.\n\n");
+        md.push_str("Modules with disproportionately high aggregate risk (total RRI > 2× median). These \"God Objects\" pull the system into their orbit — changing them affects many other modules. Consider breaking them into smaller, focused units.\n\n");
         md.push_str("| Module | Total RRI | Relationships | Directions |\n");
         md.push_str("| :--- | :--- | :--- | :--- |\n");
         for g in &report.gravity_wells {
@@ -1418,6 +1437,9 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
     // Red flags
     if !report.red_flags.is_empty() {
         md.push_str("\n## Red Flags\n\n");
+        md.push_str("Architectural anti-patterns that signal structural problems:\n");
+        md.push_str("- **FusedSibling**: Two modules with unusually high coupling density — consider merging or extracting a shared layer\n");
+        md.push_str("- **TrappedChild**: A module that imports from its parent — cannot be reused independently\n\n");
         for f in &report.red_flags {
             md.push_str(&format!(
                 "- **{}** (RRI: {:.0}) {}\n",


### PR DESCRIPTION
## Summary
All documentation and reports updated for the Software Dependency Risk Framework (v0.6.0):

### Report improvements (code changes)
- HTML report: direction badges (↓↔↑↻), RRI values, TRI metric card, Metrics Guide, section descriptions
- MD reports: Metrics Guide, TRI in summary, RRI + direction columns, Gravity Wells/Red Flags sections  
- `coupling_mode` now supported at top level of settings.json (not just inside thresholds)

### Documentation updates (8 files)
- **README.md** — RRI/TRI formulas, risk_weights config, 12 report formats, Gravity Wells, Red Flags
- **CHANGELOG.md** — v0.6.0 entries
- **docs/architecture.md** — DependencyDirection, Tarjan's SCC, new formulas
- **docs/docs.html** — Risk Weights, Coupling Mode, RRI, TRI, Gravity Wells, Red Flags sections
- **docs/changelog.html** — v0.6.0 release article
- **docs/index.html** — Updated feature cards
- **CONTRIBUTING.md** — Updated architecture descriptions
- **.agent/project-map.md** — Updated module descriptions

## Test plan
- [x] All 195 tests pass
- [x] Clippy clean
- [x] Dev version installed and tested

🤖 Generated with [Claude Code](https://claude.com/claude-code)