### PR TITLE
docs: update documentation for Phases 7-8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Configurable `risk_weights` in settings.json
 - **Gravity Well detection** (#171): Identifies "God Object" modules with disproportionately high aggregate RRI
 - **Architectural Red Flags** (#172): Fused Sibling (high-density sibling pairs) and Trapped Child (upward dependency) detection
+- **External dependency tracking**: Scanner counts unresolved imports as third-party dependencies, surfaced in audit and reports
+- **Transitive dependency direction** (weight 9) added to `DependencyDirection` for indirect dependencies through intermediate modules
+- **Layer-specific thresholds**: `allow_sibling`, `max_sibling_density`, `reduced_sibling_weight` per layer in settings.json
 - **Per-level cycle visualization** in bundle sunburst: cycle participants turn red, weakest hop highlighted with "break this side" tooltip
 - **N-cycle detection**: 3+ node cycles (A→B→C→A) now detected via DFS fallback when no mutual pairs exist in SCC
 - **Metrics Guide**: Expandable guide in HTML report and section in MD reports explaining all metrics

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,7 +67,7 @@ src/
 ├── diff.rs          - Git diff integration for PR/CI mode
 ├── baseline.rs      - Baseline file management for incremental adoption
 ├── core/            - Shared domain types (Module, Dependency, Snapshot)
-├── scanner/         - File discovery, Tree-sitter parsing, import resolution
+├── scanner/         - File discovery, Tree-sitter parsing, import resolution, external import counting
 ├── storage/         - SQLite persistence and repository patterns
 ├── analyzer/        - D_acc aggregation, BFS coupling audit, cycle detection, DependencyDirection classification, RRI/TRI computation, Gravity Well detection, Red Flag detection
 └── reporter/        - JSON, XML, Markdown, HTML, SonarCloud, Mermaid, DOT, Bundle, Dashboard, PR, Briefing, Strategy report generation

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Every violation gets a **risk score (RRI)** based on dependency direction and de
 - **Risk-weighted scoring (RRI/TRI)**: Quantify coupling risk by dependency direction and density
 - **Gravity Well detection**: Identify modules that attract excessive inbound dependencies
 - **Red Flags (Fused Sibling, Trapped Child)**: Detect structural anti-patterns in module relationships
+- **External dependency tracking**: Count third-party (unresolved) imports per module
 - **Configurable risk weights per dependency direction**: Tune scoring to match your architecture's priorities
 - **Configurable**: Thresholds, layers, dependency rules, glob ignore patterns
 
@@ -216,6 +217,8 @@ Settings are stored in `.noupling/settings.json` (auto-created on first run):
     "downward": 2,
     "sibling": 4,
     "upward": 6,
+    "external": 8,
+    "transitive": 9,
     "circular": 10
   },
   "coupling_mode": "strict"
@@ -231,7 +234,7 @@ Settings are stored in `.noupling/settings.json` (auto-created on first run):
 | `ignore_patterns` | Glob patterns for dirs/files to skip | 15 defaults |
 | `source_extensions` | File types to scan | 17 extensions |
 | `allow_inline_suppression` | Enable `noupling:ignore` comments | true |
-| `risk_weights` | Risk weights per dependency direction (downward, sibling, upward, circular) | 2, 4, 6, 10 |
+| `risk_weights` | Risk weights per dependency direction (downward, sibling, upward, external, transitive, circular) | 2, 4, 6, 8, 9, 10 |
 | `coupling_mode` | Coupling analysis mode (`strict` or `relaxed`) | `strict` |
 
 ### Architectural Layers
@@ -241,7 +244,7 @@ Define layers to suppress coupling violations that follow the intended dependenc
 ```json
 {
   "layers": [
-    { "name": "presentation", "pattern": "**/ui/**" },
+    { "name": "presentation", "pattern": "**/ui/**", "allow_sibling": false, "max_sibling_density": 3, "reduced_sibling_weight": 2 },
     { "name": "domain", "pattern": "**/domain/**" },
     { "name": "data", "pattern": "**/data/**" }
   ]
@@ -302,6 +305,8 @@ Works with `//`, `#`, and `--` comment styles. Disable with `"allow_inline_suppr
    - **Downward** (weight 2) - following the intended layer direction
    - **Sibling** (weight 4) - coupling between peer modules
    - **Upward** (weight 6) - violating the layer direction
+   - **External** (weight 8) - dependency on a third-party (unresolved) import
+   - **Transitive** (weight 9) - indirect dependency through intermediate modules
    - **Circular** (weight 10) - part of a dependency cycle
 
    **RRI** (Relationship Risk Index) = `direction_weight × density` (number of imports)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,7 +34,7 @@ Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `
 - `discovery.rs` - Recursive file walker. Filters by `source_extensions` and `ignore_patterns` from settings. Produces `Module` structs with relative paths.
 - `parser.rs` - Tree-sitter parsers for 11 languages. Each `parse_<lang>_imports()` function extracts import statements with line numbers.
 - `resolver.rs` - Maps parsed imports to actual file paths in the project. Language-specific resolution (Rust `crate::`, Kotlin dot-separated, TypeScript relative, etc.).
-- `mod.rs` - Orchestrates: discover files, parse imports in parallel (Rayon), resolve to dependencies.
+- `mod.rs` - Orchestrates: discover files, parse imports in parallel (Rayon), resolve to dependencies. Unresolved imports are counted as external (third-party) dependencies per module.
 
 ### `src/storage/`
 **Stage 2: Store.** SQLite persistence in `.noupling/history.db`.
@@ -65,7 +65,7 @@ Shared domain types used by all modules: `Module`, `ModuleType`, `Dependency`, `
 Clap argument parsing. Commands: `init`, `scan`, `audit`, `report`.
 
 ### `src/settings.rs`
-Loads `.noupling/settings.json` with thresholds, ignore patterns, source extensions, and `risk_weights` configuration (per-direction weight overrides for Downward, Sibling, Upward, and Circular). Falls back to defaults if missing.
+Loads `.noupling/settings.json` with thresholds, ignore patterns, source extensions, and `risk_weights` configuration (per-direction weight overrides for Downward, Sibling, Upward, External, Transitive, and Circular). Layers support per-layer threshold fields: `allow_sibling`, `max_sibling_density`, and `reduced_sibling_weight`. Falls back to defaults if missing.
 
 ### `src/diff.rs`
 Git integration for PR/CI mode. Shells out to `git diff --name-only <base>...HEAD` to get changed files.

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -56,6 +56,8 @@
         <li><span class="tag tag-feat">feat</span> Direction badges (&darr;&harr;&uarr;&#8635;) and RRI values in all report formats</li>
         <li><span class="tag tag-feat">feat</span> RRI-based Sonar severity mapping</li>
         <li><span class="tag tag-feat">feat</span> Dashed red edges for circular deps in Mermaid/DOT</li>
+        <li><span class="tag tag-feat">feat</span> External dependency tracking (scanner counts unresolved imports as third-party deps)</li>
+        <li><span class="tag tag-feat">feat</span> Layer-specific thresholds (<code>allow_sibling</code>, <code>max_sibling_density</code>, <code>reduced_sibling_weight</code>)</li>
         <li><span class="tag tag-feat">feat</span> N-cycle detection (3+ node cycles)</li>
       </ul>
     </article>

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -204,6 +204,8 @@ noupling hook uninstall [PATH]</code></pre>
     "downward": 2,
     "sibling": 4,
     "upward": 6,
+    "external": 8,
+    "transitive": 9,
     "circular": 10
   }
 }</code></pre>
@@ -213,6 +215,8 @@ noupling hook uninstall [PATH]</code></pre>
           <tr><td>Downward</td><td>2</td><td>Dependency follows the declared layer order. Low risk, but still tracked.</td></tr>
           <tr><td>Sibling</td><td>4</td><td>Dependency between modules at the same level. Creates horizontal coupling.</td></tr>
           <tr><td>Upward</td><td>6</td><td>Dependency flows against the layer order. Inverts the architecture.</td></tr>
+          <tr><td>External</td><td>8</td><td>Dependency on a third-party (unresolved) import. High risk due to external coupling.</td></tr>
+          <tr><td>Transitive</td><td>9</td><td>Indirect dependency through intermediate modules. Near-circular risk level.</td></tr>
           <tr><td>Circular</td><td>10</td><td>Part of a dependency cycle. Highest risk; prevents independent deployment.</td></tr>
         </tbody>
       </table>
@@ -263,6 +267,30 @@ noupling hook uninstall [PATH]</code></pre>
         <li><code>presentation &rarr; domain</code>: allowed (downward)</li>
         <li><code>data &rarr; presentation</code>: <strong>violation</strong> (upward)</li>
       </ul>
+
+      <h3>Layer-specific thresholds</h3>
+      <p>Each layer can override sibling coupling behavior with per-layer threshold fields:</p>
+<pre><code class="language-json">{
+  "layers": [
+    {
+      "name": "presentation",
+      "pattern": "**/ui/**",
+      "allow_sibling": false,
+      "max_sibling_density": 3,
+      "reduced_sibling_weight": 2
+    },
+    { "name": "domain", "pattern": "**/domain/**" },
+    { "name": "data", "pattern": "**/data/**" }
+  ]
+}</code></pre>
+      <table>
+        <thead><tr><th>Field</th><th>Type</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td><code>allow_sibling</code></td><td>bool</td><td>If <code>false</code>, sibling coupling within this layer is always flagged. Default: <code>true</code>.</td></tr>
+          <tr><td><code>max_sibling_density</code></td><td>integer</td><td>Maximum import count between siblings before the violation is escalated. Exceeding this density triggers a higher severity.</td></tr>
+          <tr><td><code>reduced_sibling_weight</code></td><td>integer</td><td>Override the sibling risk weight for dependencies within this layer. Use a lower value to de-prioritize expected lateral coupling.</td></tr>
+        </tbody>
+      </table>
 
       <div class="callout-warn callout">
         <strong>Guardrail:</strong> Layers suppress coupling violations but don't eliminate dependencies. If you find yourself adding many layers to make violations disappear, the real problem is your module boundaries.


### PR DESCRIPTION
## Summary
Documentation updates for External/Transitive deps (#174) and Layer thresholds (#175):

- External (weight 8) and Transitive (weight 9) in risk_weights docs
- Layer-specific thresholds (allow_sibling, max_sibling_density, reduced_sibling_weight)
- Scanner external import counting
- CHANGELOG + changelog.html entries

## Files updated
README.md, CHANGELOG.md, CONTRIBUTING.md, docs/architecture.md, docs/docs.html, docs/changelog.html

🤖 Generated with [Claude Code](https://claude.com/claude-code)