### PR TITLE
refactor: collapse AuditResult mutation pipeline (closes #187)

### DIFF
--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -1622,6 +1622,30 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
     }
 }
 
+/// Audit a snapshot and apply all settings-driven transformations in one call.
+///
+/// Wraps [`audit`] with the deterministic 5-step pipeline that every command
+/// previously had to spell out: severity filtering, coupling-mode adjustment,
+/// risk-weight RRI computation, layer-weight reductions, and layer filtering.
+/// Call order matters and is fixed here so callers can't get it wrong.
+///
+/// Command-specific augmentations (violation age, rule violations, layer
+/// violations, sidecar metadata, diff filtering) are intentionally left out
+/// — they vary per command and stay as separate post-hoc operations.
+pub fn audit_with_settings(
+    modules: &[Module],
+    dependencies: &[Dependency],
+    settings: &crate::settings::Settings,
+) -> AuditResult {
+    let mut result = audit(modules, dependencies);
+    result.filter_by_severity(settings.thresholds.minimum_severity);
+    result.apply_coupling_mode(settings.effective_coupling_mode());
+    result.apply_risk_weights(&settings.risk_weights);
+    result.apply_layer_weights(&settings.layers);
+    result.filter_by_layers(&settings.layers);
+    result
+}
+
 /// Compute violation ages by comparing current violations against historical snapshots.
 /// Returns an updated ViolationAgeSummary.
 pub fn compute_violation_age(
@@ -2951,5 +2975,48 @@ mod tests {
         let age = compute_violation_age(&violations, &historical);
         assert_eq!(age.new_count, 0);
         assert_eq!(age.chronic_count, 1);
+    }
+
+    // ── audit_with_settings: the deterministic settings-aware seam ──
+
+    #[test]
+    fn audit_with_settings_matches_manual_pipeline() {
+        // The seam must produce the same AuditResult as calling the 5 methods by hand
+        // in the documented order. This pins the contract so callers can't drift.
+        let modules = vec![
+            make_module("a", "src/alpha/mod.rs"),
+            make_module("b", "src/beta/mod.rs"),
+        ];
+        let deps = vec![
+            make_dep("a", "b", 1),
+            make_dep("a", "b", 2),
+            make_dep("a", "b", 3),
+        ];
+        let settings = crate::settings::Settings::default();
+
+        let auto = audit_with_settings(&modules, &deps, &settings);
+
+        let mut manual = audit(&modules, &deps);
+        manual.filter_by_severity(settings.thresholds.minimum_severity);
+        manual.apply_coupling_mode(settings.effective_coupling_mode());
+        manual.apply_risk_weights(&settings.risk_weights);
+        manual.apply_layer_weights(&settings.layers);
+        manual.filter_by_layers(&settings.layers);
+
+        assert_eq!(auto.score, manual.score);
+        assert_eq!(auto.violations.len(), manual.violations.len());
+        assert_eq!(auto.tri, manual.tri);
+        for (a, m) in auto.violations.iter().zip(manual.violations.iter()) {
+            assert_eq!(a.rri, m.rri);
+            assert_eq!(a.from_module, m.from_module);
+            assert_eq!(a.to_module, m.to_module);
+        }
+    }
+
+    #[test]
+    fn audit_with_settings_empty_project_scores_100() {
+        let settings = crate::settings::Settings::default();
+        let result = audit_with_settings(&[], &[], &settings);
+        assert!((result.score - 100.0).abs() < f64::EPSILON);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -181,12 +181,7 @@ fn run_trend(path: &str, last: usize, by_module: bool) -> anyhow::Result<()> {
         let modules = module_repo.get_by_snapshot(&snap.id)?;
         let dependencies = dep_repo.get_by_snapshot(&snap.id)?;
 
-        let mut result = analyzer::audit(&modules, &dependencies);
-        result.filter_by_severity(project_settings.thresholds.minimum_severity);
-        result.apply_coupling_mode(project_settings.effective_coupling_mode());
-        result.apply_risk_weights(&project_settings.risk_weights);
-        result.apply_layer_weights(&project_settings.layers);
-        result.filter_by_layers(&project_settings.layers);
+        let result = analyzer::audit_with_settings(&modules, &dependencies, &project_settings);
 
         let delta = match prev_score {
             Some(prev) => {
@@ -246,12 +241,7 @@ fn run_trend_by_module(
         let modules = module_repo.get_by_snapshot(&snap.id)?;
         let dependencies = dep_repo.get_by_snapshot(&snap.id)?;
 
-        let mut result = analyzer::audit(&modules, &dependencies);
-        result.filter_by_severity(settings.thresholds.minimum_severity);
-        result.apply_coupling_mode(settings.effective_coupling_mode());
-        result.apply_risk_weights(&settings.risk_weights);
-        result.apply_layer_weights(&settings.layers);
-        result.filter_by_layers(&settings.layers);
+        let result = analyzer::audit_with_settings(&modules, &dependencies, settings);
 
         let mut dir_severity: BTreeMap<String, f64> = BTreeMap::new();
         let mut dir_modules: BTreeMap<String, usize> = BTreeMap::new();
@@ -476,12 +466,7 @@ fn run_baseline(action: &str, path: &str) -> anyhow::Result<()> {
             let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
 
             let project_settings = settings::Settings::load(Path::new(path))?;
-            let mut result = analyzer::audit(&modules, &dependencies);
-            result.filter_by_severity(project_settings.thresholds.minimum_severity);
-            result.apply_coupling_mode(project_settings.effective_coupling_mode());
-            result.apply_risk_weights(&project_settings.risk_weights);
-            result.apply_layer_weights(&project_settings.layers);
-            result.filter_by_layers(&project_settings.layers);
+            let result = analyzer::audit_with_settings(&modules, &dependencies, &project_settings);
 
             baseline::save_baseline(Path::new(path), &result)?;
         }
@@ -569,12 +554,7 @@ fn run_audit(
     }
 
     // Single-project mode (existing behavior)
-    let mut result = analyzer::audit(&modules, &dependencies);
-    result.filter_by_severity(project_settings.thresholds.minimum_severity);
-    result.apply_coupling_mode(project_settings.effective_coupling_mode());
-    result.apply_risk_weights(&project_settings.risk_weights);
-    result.apply_layer_weights(&project_settings.layers);
-    result.filter_by_layers(&project_settings.layers);
+    let mut result = analyzer::audit_with_settings(&modules, &dependencies, &project_settings);
     result.rule_violations = analyzer::check_dependency_rules(
         &modules,
         &dependencies,
@@ -694,12 +674,8 @@ fn run_report(
         (modules, dependencies)
     };
 
-    let mut result = analyzer::audit(&report_modules, &report_deps);
-    result.filter_by_severity(project_settings.thresholds.minimum_severity);
-    result.apply_coupling_mode(project_settings.effective_coupling_mode());
-    result.apply_risk_weights(&project_settings.risk_weights);
-    result.apply_layer_weights(&project_settings.layers);
-    result.filter_by_layers(&project_settings.layers);
+    let mut result =
+        analyzer::audit_with_settings(&report_modules, &report_deps, &project_settings);
     result.rule_violations = analyzer::check_dependency_rules(
         &report_modules,
         &report_deps,
@@ -796,13 +772,11 @@ fn run_report(
             let (prev_score, prev_count) = if let Some(prev_snap) = prev {
                 let prev_modules = module_repo.get_by_snapshot(&prev_snap.id)?;
                 let prev_deps = dep_repo.get_by_snapshot(&prev_snap.id)?;
-                let mut prev_result = analyzer::audit(&prev_modules, &prev_deps);
-                prev_result.filter_by_severity(project_settings.thresholds.minimum_severity);
-                prev_result.apply_coupling_mode(project_settings.effective_coupling_mode());
-                prev_result.apply_risk_weights(&project_settings.risk_weights);
-                prev_result.apply_layer_weights(&project_settings.layers);
-                result.apply_layer_weights(&project_settings.layers);
-                prev_result.filter_by_layers(&project_settings.layers);
+                let prev_result = analyzer::audit_with_settings(
+                    &prev_modules,
+                    &prev_deps,
+                    &project_settings,
+                );
                 (Some(prev_result.score), Some(prev_result.violations.len()))
             } else {
                 (None, None)

--- a/src/main.rs
+++ b/src/main.rs
@@ -772,11 +772,8 @@ fn run_report(
             let (prev_score, prev_count) = if let Some(prev_snap) = prev {
                 let prev_modules = module_repo.get_by_snapshot(&prev_snap.id)?;
                 let prev_deps = dep_repo.get_by_snapshot(&prev_snap.id)?;
-                let prev_result = analyzer::audit_with_settings(
-                    &prev_modules,
-                    &prev_deps,
-                    &project_settings,
-                );
+                let prev_result =
+                    analyzer::audit_with_settings(&prev_modules, &prev_deps, &project_settings);
                 (Some(prev_result.score), Some(prev_result.violations.len()))
             } else {
                 (None, None)


### PR DESCRIPTION
Closes #187.

## Summary

- Introduce `analyzer::audit_with_settings(modules, deps, &settings) -> AuditResult` as the single seam for the deterministic 5-step pipeline (severity filter, coupling mode, risk weights, layer weights, layer filter).
- Replace the duplicated 5-line incantation at all 6 call sites in `src/main.rs` with one function call.
- Remove a vestigial `result.apply_layer_weights(...)` call inside the PR-report prev_result block (idempotent — bit-identical output before/after).

## Why

The post-construction mutation pipeline on `AuditResult` made the analyzer interface **shallow**: knowing how to use it required spelling out 5 method calls in a specific (unwritten) order. That sequence appeared verbatim at 6 sites, and one of them had a copy-paste slip. Reporters reaching back into analyzer methods (the project's own self-flagged `reporter ↔ analyzer` red flag) is downstream of this same shape.

The seam now owns the recipe; callers can't get it wrong.

## Scope notes

- **Strategy reporter (`src/reporter/strategy.rs:81-83`)** intentionally uses a 3-of-5 outlier recipe (no `apply_risk_weights`, no `apply_layer_weights`, and uses `&settings.thresholds.coupling_mode` instead of `effective_coupling_mode()`). Preserved as-is — folding it into the new seam would change behavior. Worth its own ticket if we decide the deviation is unintentional.
- **Diff filter, violation age, rule/layer violation checks, sidecar metadata** all stay as separate post-hoc operations. They're command-specific and don't suffer from the same problem; forcing them through `audit_with_settings` would over-engineer.
- The `apply_*` / `filter_*` methods remain `pub` because the strategy reporter still calls a subset, the diff filter is conditional, and tests inside `analyzer/` use them directly.

## Verification

- `cargo test` — 197 pass (195 + 2 new tests pinning the seam contract).
- `cargo clippy --all-targets` — no new warnings (the 2 pre-existing ones are unchanged).
- `noupling audit .` self-dogfood — **bit-identical** output (text and JSON report) versus baseline at `fcf40fd`.

## Test plan

- [x] All existing tests pass
- [x] New tests cover the seam contract (`audit_with_settings_matches_manual_pipeline`, `audit_with_settings_empty_project_scores_100`)
- [x] Self-audit produces identical output to baseline
- [x] No external caller of the `apply_*` / `filter_*` methods remains in `main.rs`

## Related

Part of the deepening review (`/improve-codebase-architecture`). Companion issues:
- #188 sidecar collapse
- #189 LanguageParser trait
- #190 analyzer/mod.rs split (depends on this one)
- #191 thin main.rs handlers (depends on this one)

🤖 Generated with [Claude Code](https://claude.com/claude-code)