### PR TITLE
refactor: replace JSON sidecars with typed scan results (closes #188)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -79,54 +79,6 @@ fn run_init(path: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Load diff metadata if a diff scan was performed.
-fn load_diff_meta(path: &str) -> Option<Vec<String>> {
-    let meta_path = Path::new(path).join(".noupling").join("diff-meta.json");
-    if !meta_path.exists() {
-        return None;
-    }
-    let content = std::fs::read_to_string(&meta_path).ok()?;
-    let meta: serde_json::Value = serde_json::from_str(&content).ok()?;
-    let files = meta["changed_files"]
-        .as_array()?
-        .iter()
-        .filter_map(|v| v.as_str().map(|s| s.to_string()))
-        .collect();
-    let base = meta["diff_base"].as_str().unwrap_or("");
-    if !base.is_empty() {
-        println!("Diff mode: filtered to changes against {}", base);
-    }
-    Some(files)
-}
-
-fn load_suppressed_count(path: &str) -> usize {
-    let meta_path = Path::new(path).join(".noupling").join("suppressed.json");
-    let content = std::fs::read_to_string(&meta_path).ok();
-    content
-        .and_then(|c| serde_json::from_str::<serde_json::Value>(&c).ok())
-        .and_then(|v| v["suppressed_count"].as_u64())
-        .unwrap_or(0) as usize
-}
-
-fn load_external_deps(path: &str) -> Vec<analyzer::ExternalDepMetric> {
-    let ext_path = Path::new(path).join(".noupling").join("external.json");
-    let content = match std::fs::read_to_string(&ext_path) {
-        Ok(c) => c,
-        Err(_) => return Vec::new(),
-    };
-    let data: Vec<serde_json::Value> = match serde_json::from_str(&content) {
-        Ok(d) => d,
-        Err(_) => return Vec::new(),
-    };
-    data.iter()
-        .filter_map(|v| {
-            Some(analyzer::ExternalDepMetric {
-                module_path: v["module"].as_str()?.to_string(),
-                count: v["count"].as_u64()? as usize,
-            })
-        })
-        .collect()
-}
 
 fn run_hook(action: &str, path: &str) -> anyhow::Result<()> {
     match action {
@@ -414,17 +366,7 @@ fn run_scan(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
     dep_repo.bulk_insert(&unique_deps)?;
     println!("Found {} dependencies", unique_deps.len());
 
-    // Store suppressed count for audit/report
-    let suppressed_path = project_path.join(".noupling").join("suppressed.json");
-    if result.suppressed_count > 0 {
-        let meta = serde_json::json!({ "suppressed_count": result.suppressed_count });
-        std::fs::write(&suppressed_path, serde_json::to_string(&meta)?)?;
-    } else {
-        let _ = std::fs::remove_file(&suppressed_path);
-    }
-
-    // Store external import counts for audit/report
-    let external_path = project_path.join(".noupling").join("external.json");
+    // Log external imports summary
     if !result.external_imports.is_empty() {
         let total: usize = result.external_imports.iter().map(|e| e.count).sum();
         println!(
@@ -432,30 +374,23 @@ fn run_scan(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
             total,
             result.external_imports.len()
         );
-        let data: Vec<serde_json::Value> = result
-            .external_imports
-            .iter()
-            .map(|e| serde_json::json!({"module": e.module_path, "count": e.count}))
-            .collect();
-        std::fs::write(&external_path, serde_json::to_string(&data)?)?;
-    } else {
-        let _ = std::fs::remove_file(&external_path);
     }
 
-    // Store diff metadata alongside the snapshot
-    if let Some(ref files) = changed_files {
-        let diff_meta = serde_json::json!({
-            "diff_base": diff_base.unwrap_or(""),
-            "changed_files": files,
-            "changed_count": files.len(),
-        });
-        let meta_path = project_path.join(".noupling").join("diff-meta.json");
-        std::fs::write(&meta_path, serde_json::to_string_pretty(&diff_meta)?)?;
-    } else {
-        // Remove old diff metadata if doing a full scan
-        let meta_path = project_path.join(".noupling").join("diff-meta.json");
-        let _ = std::fs::remove_file(&meta_path);
-    }
+    // Persist scan metadata in SQLite alongside the snapshot
+    let scan_meta = storage::SnapshotMeta {
+        suppressed_count: result.suppressed_count,
+        diff_base: diff_base.map(|s| s.to_string()),
+        diff_changed_files: changed_files.clone(),
+        external_deps: result
+            .external_imports
+            .iter()
+            .map(|e| storage::ExternalDepRow {
+                module_path: e.module_path.clone(),
+                count: e.count,
+            })
+            .collect(),
+    };
+    snap_repo.save_meta(&snapshot.id, &scan_meta)?;
 
     println!("Scan complete. Database: {}", db_path.display());
     Ok(())
@@ -583,11 +518,18 @@ fn run_audit(
     result.layer_violations =
         analyzer::check_layer_rules(&modules, &dependencies, &project_settings.layers);
 
-    // Load suppressed count from scan
-    result.suppressed_count = load_suppressed_count(path);
-    let ext_deps = load_external_deps(path);
-    result.total_external_imports = ext_deps.iter().map(|e| e.count).sum();
-    result.external_deps = ext_deps;
+    // Load scan-time metadata from SQLite
+    let scan_meta = snap_repo.get_meta(&snapshot.id)?;
+    result.suppressed_count = scan_meta.suppressed_count;
+    result.external_deps = scan_meta
+        .external_deps
+        .iter()
+        .map(|e| analyzer::ExternalDepMetric {
+            module_path: e.module_path.clone(),
+            count: e.count,
+        })
+        .collect();
+    result.total_external_imports = result.external_deps.iter().map(|e| e.count).sum();
 
     // Compute violation age from snapshot history
     let all_snapshots = snap_repo.get_all()?;
@@ -609,8 +551,13 @@ fn run_audit(
     result.violation_age = analyzer::compute_violation_age(&result.violations, &historical);
 
     // Apply diff filter if a diff scan was performed
-    if let Some(changed_files) = load_diff_meta(path) {
-        result.filter_by_changed_files(&changed_files);
+    if let Some(ref changed_files) = scan_meta.diff_changed_files {
+        if let Some(ref base) = scan_meta.diff_base {
+            if !base.is_empty() {
+                println!("Diff mode: filtered to changes against {}", base);
+            }
+        }
+        result.filter_by_changed_files(changed_files);
     }
 
     // Apply baseline filter
@@ -708,15 +655,22 @@ fn run_report(
     result.layer_violations =
         analyzer::check_layer_rules(&report_modules, &report_deps, &project_settings.layers);
 
-    // Load suppressed count from scan
-    result.suppressed_count = load_suppressed_count(path);
-    let ext_deps = load_external_deps(path);
-    result.total_external_imports = ext_deps.iter().map(|e| e.count).sum();
-    result.external_deps = ext_deps;
+    // Load scan-time metadata from SQLite
+    let scan_meta = snap_repo.get_meta(&snapshot.id)?;
+    result.suppressed_count = scan_meta.suppressed_count;
+    result.external_deps = scan_meta
+        .external_deps
+        .iter()
+        .map(|e| analyzer::ExternalDepMetric {
+            module_path: e.module_path.clone(),
+            count: e.count,
+        })
+        .collect();
+    result.total_external_imports = result.external_deps.iter().map(|e| e.count).sum();
 
     // Apply diff filter if a diff scan was performed
-    if let Some(changed_files) = load_diff_meta(path) {
-        result.filter_by_changed_files(&changed_files);
+    if let Some(ref changed_files) = scan_meta.diff_changed_files {
+        result.filter_by_changed_files(changed_files);
     }
 
     let report_dir = Path::new(path).join(".noupling");

--- a/src/main.rs
+++ b/src/main.rs
@@ -79,7 +79,6 @@ fn run_init(path: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
-
 fn run_hook(action: &str, path: &str) -> anyhow::Result<()> {
     match action {
         "install" => hook::install(Path::new(path)),

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -35,7 +35,10 @@ impl Database {
             "CREATE TABLE IF NOT EXISTS snapshots (
                 id TEXT PRIMARY KEY,
                 timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
-                root_path TEXT NOT NULL
+                root_path TEXT NOT NULL,
+                suppressed_count INTEGER NOT NULL DEFAULT 0,
+                diff_base TEXT,
+                diff_changed_files TEXT
             );
 
             CREATE TABLE IF NOT EXISTS modules (
@@ -53,8 +56,25 @@ impl Database {
                 to_module_id TEXT REFERENCES modules(id),
                 line_number INTEGER,
                 PRIMARY KEY (from_module_id, to_module_id, line_number)
+            );
+
+            CREATE TABLE IF NOT EXISTS snapshot_external_deps (
+                snapshot_id TEXT REFERENCES snapshots(id),
+                module_path TEXT NOT NULL,
+                count INTEGER NOT NULL,
+                PRIMARY KEY (snapshot_id, module_path)
             );",
         )?;
+        // Migrate existing snapshots table if it lacks the new columns
+        let _ = self.conn.execute_batch(
+            "ALTER TABLE snapshots ADD COLUMN suppressed_count INTEGER NOT NULL DEFAULT 0;",
+        );
+        let _ = self.conn.execute_batch(
+            "ALTER TABLE snapshots ADD COLUMN diff_base TEXT;",
+        );
+        let _ = self.conn.execute_batch(
+            "ALTER TABLE snapshots ADD COLUMN diff_changed_files TEXT;",
+        );
         Ok(())
     }
 }
@@ -113,7 +133,31 @@ mod tests {
             .unwrap()
             .filter_map(|r| r.ok())
             .collect();
-        assert_eq!(columns, vec!["id", "timestamp", "root_path"]);
+        assert_eq!(
+            columns,
+            vec![
+                "id",
+                "timestamp",
+                "root_path",
+                "suppressed_count",
+                "diff_base",
+                "diff_changed_files"
+            ]
+        );
+    }
+
+    #[test]
+    fn snapshot_external_deps_table_exists() {
+        let db = Database::open_in_memory().unwrap();
+        let tables: Vec<String> = db
+            .conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .filter_map(|r| r.ok())
+            .collect();
+        assert!(tables.contains(&"snapshot_external_deps".to_string()));
     }
 
     #[test]

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -69,12 +69,12 @@ impl Database {
         let _ = self.conn.execute_batch(
             "ALTER TABLE snapshots ADD COLUMN suppressed_count INTEGER NOT NULL DEFAULT 0;",
         );
-        let _ = self.conn.execute_batch(
-            "ALTER TABLE snapshots ADD COLUMN diff_base TEXT;",
-        );
-        let _ = self.conn.execute_batch(
-            "ALTER TABLE snapshots ADD COLUMN diff_changed_files TEXT;",
-        );
+        let _ = self
+            .conn
+            .execute_batch("ALTER TABLE snapshots ADD COLUMN diff_base TEXT;");
+        let _ = self
+            .conn
+            .execute_batch("ALTER TABLE snapshots ADD COLUMN diff_changed_files TEXT;");
         Ok(())
     }
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -4,3 +4,4 @@ mod db;
 pub mod repository;
 
 pub use db::Database;
+pub use repository::{ExternalDepRow, SnapshotMeta};

--- a/src/storage/repository.rs
+++ b/src/storage/repository.rs
@@ -3,6 +3,26 @@ use rusqlite::Connection;
 
 use crate::core::{Dependency, Module, ModuleType, Snapshot};
 
+/// Scan metadata stored alongside a snapshot in SQLite.
+#[derive(Debug, Default)]
+pub struct SnapshotMeta {
+    /// Number of imports suppressed by `noupling:ignore` comments.
+    pub suppressed_count: usize,
+    /// The base branch/commit used for diff mode, if any.
+    pub diff_base: Option<String>,
+    /// Files changed compared to the diff base, if diff mode was used.
+    pub diff_changed_files: Option<Vec<String>>,
+    /// Per-module count of external (third-party) imports.
+    pub external_deps: Vec<ExternalDepRow>,
+}
+
+/// One row from snapshot_external_deps.
+#[derive(Debug, Clone)]
+pub struct ExternalDepRow {
+    pub module_path: String,
+    pub count: usize,
+}
+
 /// Repository for creating and querying scan snapshots.
 pub struct SnapshotRepository<'a> {
     conn: &'a Connection,
@@ -77,6 +97,74 @@ impl<'a> SnapshotRepository<'a> {
             })
         })?;
         Ok(rows.filter_map(|r| r.ok()).collect())
+    }
+
+    /// Persist scan-time metadata for an existing snapshot.
+    pub fn save_meta(&self, snapshot_id: &str, meta: &SnapshotMeta) -> Result<()> {
+        let diff_changed_files_json = meta
+            .diff_changed_files
+            .as_ref()
+            .map(serde_json::to_string)
+            .transpose()?;
+
+        self.conn.execute(
+            "UPDATE snapshots SET suppressed_count = ?1, diff_base = ?2, diff_changed_files = ?3 WHERE id = ?4",
+            rusqlite::params![
+                meta.suppressed_count as i64,
+                meta.diff_base,
+                diff_changed_files_json,
+                snapshot_id,
+            ],
+        )?;
+
+        // Insert external dep rows
+        let tx = self.conn.unchecked_transaction()?;
+        {
+            let mut stmt = tx.prepare(
+                "INSERT OR REPLACE INTO snapshot_external_deps (snapshot_id, module_path, count) VALUES (?1, ?2, ?3)",
+            )?;
+            for row in &meta.external_deps {
+                stmt.execute(rusqlite::params![snapshot_id, row.module_path, row.count as i64])?;
+            }
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    /// Load scan-time metadata for a snapshot.
+    pub fn get_meta(&self, snapshot_id: &str) -> Result<SnapshotMeta> {
+        let (suppressed_count, diff_base, diff_changed_files_json): (i64, Option<String>, Option<String>) = self
+            .conn
+            .query_row(
+                "SELECT suppressed_count, diff_base, diff_changed_files FROM snapshots WHERE id = ?1",
+                rusqlite::params![snapshot_id],
+                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
+            )
+            .unwrap_or((0, None, None));
+
+        let diff_changed_files: Option<Vec<String>> = diff_changed_files_json
+            .as_deref()
+            .and_then(|s| serde_json::from_str(s).ok());
+
+        let mut ext_stmt = self.conn.prepare(
+            "SELECT module_path, count FROM snapshot_external_deps WHERE snapshot_id = ?1",
+        )?;
+        let external_deps: Vec<ExternalDepRow> = ext_stmt
+            .query_map(rusqlite::params![snapshot_id], |row| {
+                Ok(ExternalDepRow {
+                    module_path: row.get(0)?,
+                    count: row.get::<_, i64>(1)? as usize,
+                })
+            })?
+            .filter_map(|r| r.ok())
+            .collect();
+
+        Ok(SnapshotMeta {
+            suppressed_count: suppressed_count as usize,
+            diff_base,
+            diff_changed_files,
+            external_deps,
+        })
     }
 }
 
@@ -413,5 +501,56 @@ mod tests {
         let dep_repo = DependencyRepository::new(&db.conn);
         let result = dep_repo.get_by_snapshot(&snap.id).unwrap();
         assert!(result.is_empty());
+    }
+
+    // ── SnapshotMeta (scan-time metadata) ──
+
+    #[test]
+    fn snapshot_meta_save_and_load_roundtrip() {
+        let db = setup_db();
+        let repo = SnapshotRepository::new(&db.conn);
+        let snap = repo.create("/project").unwrap();
+
+        let meta = SnapshotMeta {
+            suppressed_count: 7,
+            diff_base: Some("origin/main".to_string()),
+            diff_changed_files: Some(vec!["src/foo.rs".to_string(), "src/bar.rs".to_string()]),
+            external_deps: vec![
+                ExternalDepRow {
+                    module_path: "src/main.rs".to_string(),
+                    count: 3,
+                },
+                ExternalDepRow {
+                    module_path: "src/lib.rs".to_string(),
+                    count: 5,
+                },
+            ],
+        };
+
+        repo.save_meta(&snap.id, &meta).unwrap();
+        let loaded = repo.get_meta(&snap.id).unwrap();
+
+        assert_eq!(loaded.suppressed_count, 7);
+        assert_eq!(loaded.diff_base.as_deref(), Some("origin/main"));
+        let files = loaded.diff_changed_files.unwrap();
+        assert_eq!(files.len(), 2);
+        assert!(files.contains(&"src/foo.rs".to_string()));
+        assert_eq!(loaded.external_deps.len(), 2);
+        let total: usize = loaded.external_deps.iter().map(|e| e.count).sum();
+        assert_eq!(total, 8);
+    }
+
+    #[test]
+    fn snapshot_meta_defaults_when_not_set() {
+        let db = setup_db();
+        let repo = SnapshotRepository::new(&db.conn);
+        let snap = repo.create("/project").unwrap();
+
+        // Don't call save_meta — get_meta should return safe defaults
+        let loaded = repo.get_meta(&snap.id).unwrap();
+        assert_eq!(loaded.suppressed_count, 0);
+        assert!(loaded.diff_base.is_none());
+        assert!(loaded.diff_changed_files.is_none());
+        assert!(loaded.external_deps.is_empty());
     }
 }

--- a/src/storage/repository.rs
+++ b/src/storage/repository.rs
@@ -124,7 +124,11 @@ impl<'a> SnapshotRepository<'a> {
                 "INSERT OR REPLACE INTO snapshot_external_deps (snapshot_id, module_path, count) VALUES (?1, ?2, ?3)",
             )?;
             for row in &meta.external_deps {
-                stmt.execute(rusqlite::params![snapshot_id, row.module_path, row.count as i64])?;
+                stmt.execute(rusqlite::params![
+                    snapshot_id,
+                    row.module_path,
+                    row.count as i64
+                ])?;
             }
         }
         tx.commit()?;


### PR DESCRIPTION
## Summary

- **Option A chosen** (SQLite persistence): data that belongs to a snapshot lives with the snapshot — no filesystem coupling across processes.
- Three sidecar files (`diff-meta.json`, `suppressed.json`, `external.json`) are no longer written by `noupling scan`.
- `run_audit` and `run_report` read the same data via a new `SnapshotRepository::get_meta()` method.

## Schema changes

New columns on `snapshots` table:
- `suppressed_count INTEGER NOT NULL DEFAULT 0`
- `diff_base TEXT` (nullable)
- `diff_changed_files TEXT` (JSON-encoded list, nullable)

New table:
```sql
CREATE TABLE IF NOT EXISTS snapshot_external_deps (
    snapshot_id TEXT REFERENCES snapshots(id),
    module_path TEXT NOT NULL,
    count       INTEGER NOT NULL,
    PRIMARY KEY (snapshot_id, module_path)
);
```

Existing databases are migrated forward via `ALTER TABLE … ADD COLUMN` (no-op if column already exists).

## New storage API

- `storage::SnapshotMeta` struct with `suppressed_count`, `diff_base`, `diff_changed_files`, `external_deps`
- `SnapshotRepository::save_meta(snapshot_id, &SnapshotMeta)` — called in `run_scan`
- `SnapshotRepository::get_meta(snapshot_id) -> SnapshotMeta` — called in `run_audit` + `run_report`

## LOC removed from src/main.rs

Deleted helpers: ~44 LOC (`load_diff_meta` 17 + `load_suppressed_count` 8 + `load_external_deps` 19)
Removed sidecar write blocks in `run_scan`: ~28 LOC
Total removed: ~72 LOC

## Before / after `ls .noupling/`

**Before:** `diff-meta.json  external.json  history.db  report.json  settings.json  suppressed.json`
**After:**  `history.db  report.json  settings.json`

## Verification

- `cargo test`: 198 passed (195 baseline + 3 new tests for the persistence path)
- `cargo clippy --all-targets -- -W clippy::all`: 2 pre-existing warnings only (no new warnings)
- `noupling scan && noupling audit` and `noupling report --format json` produce identical output to baseline
- `grep -n 'load_diff_meta\|load_suppressed_count\|load_external_deps' src/main.rs` returns nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)