### PR TITLE
refactor: move DependencyDirection from core to analyzer (closes #197)

### DIFF
--- a/src/analyzer/coupling.rs
+++ b/src/analyzer/coupling.rs
@@ -7,7 +7,8 @@ use std::collections::BTreeMap;
 use fxhash::{FxHashMap, FxHashSet};
 
 use super::cycles::detect_sibling_cycles;
-use crate::core::{Dependency, DependencyDirection, Module};
+use super::DependencyDirection;
+use crate::core::{Dependency, Module};
 
 /// A detected coupling violation or circular dependency between modules.
 #[derive(Debug, Clone)]

--- a/src/analyzer/direction.rs
+++ b/src/analyzer/direction.rs
@@ -1,0 +1,52 @@
+//! Dependency direction classification for the architectural risk framework.
+
+use serde::{Deserialize, Serialize};
+
+/// The architectural direction of a dependency between two modules.
+///
+/// Used to assign risk weights in the dependency risk framework:
+/// downward (2) < sibling (4) < upward (6) < external (8) < transitive (9) < circular (10).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum DependencyDirection {
+    /// Parent directory imports from child directory. Low risk.
+    #[serde(rename = "downward")]
+    Downward,
+    /// Same-level directories import each other. Moderate risk.
+    #[serde(rename = "sibling")]
+    Sibling,
+    /// Child directory imports from parent directory. High risk.
+    #[serde(rename = "upward")]
+    Upward,
+    /// Import of a third-party package not in the project source tree. Critical.
+    #[serde(rename = "external")]
+    External,
+    /// Indirect dependency through another module (A depends on C only via B). Extreme.
+    #[serde(rename = "transitive")]
+    Transitive,
+    /// Mutual or transitive cycle between directories. Lethal.
+    #[serde(rename = "circular")]
+    Circular,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DependencyDirection;
+
+    #[test]
+    fn dependency_direction_serde_roundtrip() {
+        let variants = [
+            (DependencyDirection::Downward, "\"downward\""),
+            (DependencyDirection::Sibling, "\"sibling\""),
+            (DependencyDirection::Upward, "\"upward\""),
+            (DependencyDirection::External, "\"external\""),
+            (DependencyDirection::Transitive, "\"transitive\""),
+            (DependencyDirection::Circular, "\"circular\""),
+        ];
+        for (variant, expected_json) in &variants {
+            let json = serde_json::to_string(variant).unwrap();
+            assert_eq!(&json, expected_json);
+            let deserialized: DependencyDirection = serde_json::from_str(&json).unwrap();
+            assert_eq!(&deserialized, variant);
+        }
+    }
+}

--- a/src/analyzer/gravity_wells.rs
+++ b/src/analyzer/gravity_wells.rs
@@ -3,7 +3,7 @@
 //! system into their orbit, making extraction or replacement difficult.
 
 use super::CouplingViolation;
-use crate::core::DependencyDirection;
+use super::DependencyDirection;
 
 /// A module with disproportionately high aggregate RRI across multiple
 /// dependency types. These "God Objects" pull the system into their orbit,

--- a/src/analyzer/layers.rs
+++ b/src/analyzer/layers.rs
@@ -4,7 +4,8 @@
 use fxhash::FxHashMap;
 
 use super::AuditResult;
-use crate::core::{Dependency, DependencyDirection, Module};
+use super::DependencyDirection;
+use crate::core::{Dependency, Module};
 
 /// A violation of architectural layer ordering.
 #[derive(Debug, Clone)]

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -3,13 +3,14 @@
 //! Computes coupling violations and circular dependencies using
 //! bottom-up D_acc aggregation and top-down BFS sibling analysis.
 
-use crate::core::{Dependency, DependencyDirection, Module};
+use crate::core::{Dependency, Module};
 
 mod actions;
 mod cohesion;
 mod coupling;
 mod critical_path;
 mod cycles;
+mod direction;
 mod gravity_wells;
 mod independence;
 mod layers;
@@ -18,6 +19,8 @@ mod monorepo;
 mod red_flags;
 mod rules;
 mod violation_age;
+
+pub use direction::DependencyDirection;
 
 pub use actions::compute_top_actions;
 #[allow(unused_imports)] // Public API surface: kept reachable as analyzer::TopAction

--- a/src/analyzer/red_flags.rs
+++ b/src/analyzer/red_flags.rs
@@ -2,7 +2,7 @@
 //! anti-patterns derived from the violation set.
 
 use super::CouplingViolation;
-use crate::core::DependencyDirection;
+use super::DependencyDirection;
 
 /// An architectural anti-pattern detected from the dependency analysis.
 #[derive(Debug, Clone)]

--- a/src/analyzer/violation_age.rs
+++ b/src/analyzer/violation_age.rs
@@ -50,7 +50,7 @@ pub fn compute_violation_age(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::core::DependencyDirection;
+    use crate::analyzer::DependencyDirection;
 
     #[test]
     fn violation_age_all_new() {

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -113,8 +113,8 @@ fn chrono_now() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analyzer::DependencyDirection;
     use crate::analyzer::ViolationAgeSummary;
-    use crate::core::DependencyDirection;
 
     fn make_coupling(from: &str, to: &str) -> CouplingViolation {
         CouplingViolation {

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -2,32 +2,6 @@
 
 use serde::{Deserialize, Serialize};
 
-/// The architectural direction of a dependency between two modules.
-///
-/// Used to assign risk weights in the dependency risk framework:
-/// downward (2) < sibling (4) < upward (6) < external (8) < transitive (9) < circular (10).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
-pub enum DependencyDirection {
-    /// Parent directory imports from child directory. Low risk.
-    #[serde(rename = "downward")]
-    Downward,
-    /// Same-level directories import each other. Moderate risk.
-    #[serde(rename = "sibling")]
-    Sibling,
-    /// Child directory imports from parent directory. High risk.
-    #[serde(rename = "upward")]
-    Upward,
-    /// Import of a third-party package not in the project source tree. Critical.
-    #[serde(rename = "external")]
-    External,
-    /// Indirect dependency through another module (A depends on C only via B). Extreme.
-    #[serde(rename = "transitive")]
-    Transitive,
-    /// Mutual or transitive cycle between directories. Lethal.
-    #[serde(rename = "circular")]
-    Circular,
-}
-
 /// Whether a discovered module is a file or directory.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum ModuleType {
@@ -90,25 +64,6 @@ pub struct Snapshot {
 #[cfg(test)]
 mod tests {
     use serde_json;
-
-    #[test]
-    fn dependency_direction_serde_roundtrip() {
-        use super::DependencyDirection;
-        let variants = [
-            (DependencyDirection::Downward, "\"downward\""),
-            (DependencyDirection::Sibling, "\"sibling\""),
-            (DependencyDirection::Upward, "\"upward\""),
-            (DependencyDirection::External, "\"external\""),
-            (DependencyDirection::Transitive, "\"transitive\""),
-            (DependencyDirection::Circular, "\"circular\""),
-        ];
-        for (variant, expected_json) in &variants {
-            let json = serde_json::to_string(variant).unwrap();
-            assert_eq!(&json, expected_json);
-            let deserialized: DependencyDirection = serde_json::from_str(&json).unwrap();
-            assert_eq!(&deserialized, variant);
-        }
-    }
 
     #[test]
     fn module_type_serializes_to_string() {

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -263,7 +263,7 @@ mod tests {
             depth: 1,
             weight: 1,
             severity: 0.5,
-            direction: crate::core::DependencyDirection::Sibling,
+            direction: crate::analyzer::DependencyDirection::Sibling,
             rri: 0.0,
             is_circular: false,
             cycle_path: Vec::new(),

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -27,7 +27,7 @@ struct ViolationInfo {
     to_module: String,
     severity: f64,
     rri: f64,
-    direction: crate::core::DependencyDirection,
+    direction: crate::analyzer::DependencyDirection,
     #[allow(dead_code)]
     weight: usize,
     is_circular: bool,
@@ -463,24 +463,24 @@ fn module_label(path: &str, current_dir: &str) -> String {
     }
 }
 
-fn direction_badge(dir: &crate::core::DependencyDirection) -> &'static str {
+fn direction_badge(dir: &crate::analyzer::DependencyDirection) -> &'static str {
     match dir {
-        crate::core::DependencyDirection::Downward => {
+        crate::analyzer::DependencyDirection::Downward => {
             "<span title=\"Downward dependency\" style=\"color:#22c55e\">\u{2193}</span>"
         }
-        crate::core::DependencyDirection::Sibling => {
+        crate::analyzer::DependencyDirection::Sibling => {
             "<span title=\"Sibling dependency\" style=\"color:#eab308\">\u{2194}</span>"
         }
-        crate::core::DependencyDirection::Upward => {
+        crate::analyzer::DependencyDirection::Upward => {
             "<span title=\"Upward dependency\" style=\"color:#ef4444\">\u{2191}</span>"
         }
-        crate::core::DependencyDirection::External => {
+        crate::analyzer::DependencyDirection::External => {
             "<span title=\"External dependency\" style=\"color:#f97316\">\u{2197}</span>"
         }
-        crate::core::DependencyDirection::Transitive => {
+        crate::analyzer::DependencyDirection::Transitive => {
             "<span title=\"Transitive dependency\" style=\"color:#a855f7\">\u{21dd}</span>"
         }
-        crate::core::DependencyDirection::Circular => {
+        crate::analyzer::DependencyDirection::Circular => {
             "<span title=\"Circular dependency\" style=\"color:#dc2626\">\u{21bb}</span>"
         }
     }
@@ -1128,7 +1128,7 @@ mod tests {
                 to_module: "src/storage/mod.rs".to_string(),
                 depth: 1,
                 severity: 0.5,
-                direction: crate::core::DependencyDirection::Sibling,
+                direction: crate::analyzer::DependencyDirection::Sibling,
                 rri: 0.0,
                 is_circular: false,
                 cycle_path: Vec::new(),

--- a/src/reporter/md.rs
+++ b/src/reporter/md.rs
@@ -288,12 +288,12 @@ fn render_dir_page(
                     .and_then(|f| f.to_str())
                     .unwrap_or(&v.to_module);
                 let dir_symbol = match v.direction {
-                    crate::core::DependencyDirection::Downward => "↓",
-                    crate::core::DependencyDirection::Sibling => "↔",
-                    crate::core::DependencyDirection::Upward => "↑",
-                    crate::core::DependencyDirection::External => "↗",
-                    crate::core::DependencyDirection::Transitive => "⇝",
-                    crate::core::DependencyDirection::Circular => "↻",
+                    crate::analyzer::DependencyDirection::Downward => "↓",
+                    crate::analyzer::DependencyDirection::Sibling => "↔",
+                    crate::analyzer::DependencyDirection::Upward => "↑",
+                    crate::analyzer::DependencyDirection::External => "↗",
+                    crate::analyzer::DependencyDirection::Transitive => "⇝",
+                    crate::analyzer::DependencyDirection::Circular => "↻",
                 };
                 md.push_str(&format!(
                     "| {:.2} | {:.0} | {} | `{}` | `{}` |\n",

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -782,12 +782,12 @@ pub fn format_text(result: &AuditResult) -> String {
         output.push('\n');
         for v in &result.violations {
             let dir_label = match v.direction {
-                crate::core::DependencyDirection::Downward => "\u{2193}",
-                crate::core::DependencyDirection::Sibling => "\u{2194}",
-                crate::core::DependencyDirection::Upward => "\u{2191}",
-                crate::core::DependencyDirection::External => "\u{2197}",
-                crate::core::DependencyDirection::Transitive => "\u{21dd}",
-                crate::core::DependencyDirection::Circular => "\u{21bb}",
+                crate::analyzer::DependencyDirection::Downward => "\u{2193}",
+                crate::analyzer::DependencyDirection::Sibling => "\u{2194}",
+                crate::analyzer::DependencyDirection::Upward => "\u{2191}",
+                crate::analyzer::DependencyDirection::External => "\u{2197}",
+                crate::analyzer::DependencyDirection::Transitive => "\u{21dd}",
+                crate::analyzer::DependencyDirection::Circular => "\u{21bb}",
             };
             let rri_label = if v.rri > 0.0 {
                 format!(" RRI:{:.0}", v.rri)
@@ -1482,7 +1482,7 @@ mod tests {
             to_module: to.to_string(),
             depth,
             severity,
-            direction: crate::core::DependencyDirection::Sibling,
+            direction: crate::analyzer::DependencyDirection::Sibling,
             rri: 0.0,
             is_circular: false,
             cycle_path: Vec::new(),


### PR DESCRIPTION
## Summary

- `DependencyDirection` is an analysis-domain concept (the analyzer *derives* this classification when weighting dependencies), not a scanner-output primitive like `Module`, `Dependency`, or `Snapshot`.
- Moved to `src/analyzer/direction.rs` (option b — own file matching `coupling.rs` style), re-exported as `pub use direction::DependencyDirection` from `src/analyzer/mod.rs`.
- The `dependency_direction_serde_roundtrip` test moved with the type to `direction.rs`.

## Consumer files updated (12 total)

**Analyzer submodules** (now use `super::DependencyDirection`):
- `src/analyzer/coupling.rs`
- `src/analyzer/gravity_wells.rs`
- `src/analyzer/layers.rs`
- `src/analyzer/mod.rs`
- `src/analyzer/red_flags.rs`
- `src/analyzer/violation_age.rs`
- `src/analyzer/tests.rs` (via `super::*` — no explicit import change needed)

**External consumers** (now use `crate::analyzer::DependencyDirection`):
- `src/reporter/mod.rs`
- `src/reporter/html.rs`
- `src/reporter/md.rs`
- `src/reporter/graph.rs`
- `src/baseline.rs`

## Before → After (red flags in audit output)

**Before:**
```
Red Flags (1):
  ⚠ src/analyzer and src/core have 19 imports between them (median: 9).
```

**After:**
```
(no Red Flags section — the flag is completely gone)
```

`src/core/mod.rs` fan-in also dropped from 33 → 29 dependents.

## Verification

- `cargo test` — 201 tests pass (200 unit + 1 integration)
- `cargo clippy --all-targets -- -W clippy::all` — 1 warning (pre-existing `use serde_json;` in `src/core/mod.rs`); no new warnings
- `cargo fmt --check` — passes
- `grep -rn 'use crate::core::DependencyDirection' src/` — returns nothing

Note: The `noupling audit .` self-scan output differs from baseline because the refactoring added `src/analyzer/direction.rs` as a new source file (59 modules vs 58) and removed cross-module imports — this is expected structural improvement, not a behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)