### PR TITLE
chore: tighten CI score gate to 95 and remove clippy warning

### DIFF
--- a/.github/workflows/noupling-pr.yml
+++ b/.github/workflows/noupling-pr.yml
@@ -114,6 +114,6 @@ jobs:
       - name: Fail on threshold
         if: always()
         run: |
-          # Fail if score below 80 (customize this threshold)
+          # Fail if score below 95 (we're currently at 100; this leaves a small noise margin)
           noupling scan .
-          noupling audit . --fail-below 80
+          noupling audit . --fail-below 95

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -63,8 +63,6 @@ pub struct Snapshot {
 
 #[cfg(test)]
 mod tests {
-    use serde_json;
-
     #[test]
     fn module_type_serializes_to_string() {
         let file_type = super::ModuleType::File;


### PR DESCRIPTION
Two small follow-ups from the architectural pass review:

## Changes

1. **Bump `--fail-below` 80 → 95** in `.github/workflows/noupling-pr.yml`. We're at 100/100 with 0 violations; 95 leaves a small noise margin while catching real regressions.
2. **Remove redundant `use serde_json;`** in `src/core/mod.rs` tests module. Fully-qualified `serde_json::to_string(...)` is already used inside the tests; the import was a no-op clippy was warning about.

## Verification

- 201 tests pass
- `cargo clippy --all-targets -- -W clippy::all` — **0 warnings** (was 1)
- `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)