### PR TITLE
infra: opt-in pre-commit hook for fmt + clippy (closes #201)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Pre-commit hook: checks formatting and lints with Clippy.
+# Opt-in — activate once per clone with:
+#   git config core.hooksPath .githooks
+
+cargo fmt --check
+if [ $? -ne 0 ]; then
+    printf '❌ Code is not formatted. Run: cargo fmt\n'
+    exit 1
+fi
+
+cargo clippy --all-targets -- -W clippy::all -D warnings
+if [ $? -ne 0 ]; then
+    printf '❌ Clippy reports issues. Review the output above.\n'
+    exit 1
+fi
+
+printf '✅ Pre-commit checks passed\n'
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,16 @@ git push -u origin feature/42-add-ruby-parser
 gh pr create
 ```
 
+## Local Hooks (recommended)
+
+The repo ships an opt-in pre-commit hook that runs `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` before each commit, catching issues before CI does. Enable it once per clone:
+
+```bash
+git config core.hooksPath .githooks
+```
+
+The hook is opt-in — it does nothing until you run that command. Disable with `git config --unset core.hooksPath`.
+
 ## Coding Standards
 
 - **Format**: Run `cargo fmt` before committing.


### PR DESCRIPTION
Closes #201.

## What

`.githooks/pre-commit` runs `cargo fmt --check` and `cargo clippy --all-targets -- -W clippy::all -D warnings`. Blocks the commit if either fails, with a clear error.

## Setup (one-time per clone)

```bash
git config core.hooksPath .githooks
```

Documented in CONTRIBUTING.md. Disable with `git config --unset core.hooksPath`.

## Why opt-in

- No new dependencies (no `cargo-husky`).
- No surprise behavior on first build.
- Contributors who already have their own hook setup are respected.

## Verification

End-to-end tested: enabled the hook, added a file with trailing whitespace, attempted to commit — hook blocked with `❌ Code is not formatted. Run: cargo fmt`. Reverted, the next clean commit passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)