### PR TITLE
ci: auto-update Homebrew tap via repository_dispatch (closes #210)

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -1,22 +1,39 @@
 name: Update Homebrew
 
+# Triggers:
+#   release: published    — manual release via the GitHub UI.
+#   repository_dispatch   — fired by release.yml after the binary build job.
+#                          GITHUB_TOKEN-created release events don't chain by
+#                          design; repository_dispatch is the documented escape
+#                          hatch and needs no extra secret.
 on:
   release:
     types: [published]
+  repository_dispatch:
+    types: [release-published]
 
 jobs:
   update-formula:
     name: Update Homebrew Formula
     runs-on: ubuntu-latest
     steps:
-      - name: Extract version
-        id: version
-        run: echo "version=${GITHUB_REF_NAME#v}" >> $GITHUB_OUTPUT
+      - name: Resolve tag
+        id: resolve
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            TAG="${{ github.event.client_payload.tag }}"
+          else
+            TAG="${{ github.ref_name }}"
+          fi
+          VERSION="${TAG#v}"
+          echo "tag=${TAG}" >> $GITHUB_OUTPUT
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Resolved: tag=${TAG} version=${VERSION}"
 
       - name: Calculate SHA256
         id: sha
         run: |
-          SHA=$(curl -sL "https://github.com/${{ github.repository }}/archive/refs/tags/${{ github.ref_name }}.tar.gz" | sha256sum | awk '{print $1}')
+          SHA=$(curl -sL "https://github.com/${{ github.repository }}/archive/refs/tags/${{ steps.resolve.outputs.tag }}.tar.gz" | sha256sum | awk '{print $1}')
           echo "sha256=$SHA" >> $GITHUB_OUTPUT
           echo "SHA256: $SHA"
 
@@ -27,9 +44,9 @@ jobs:
           git clone https://x-access-token:${TAP_TOKEN}@github.com/pererikbergman/homebrew-noupling.git tap
           cd tap
 
-          VERSION="${{ steps.version.outputs.version }}"
+          VERSION="${{ steps.resolve.outputs.version }}"
           SHA256="${{ steps.sha.outputs.sha256 }}"
-          TAG="${{ github.ref_name }}"
+          TAG="${{ steps.resolve.outputs.tag }}"
           URL="https://github.com/pererikbergman/noupling/archive/refs/tags/${TAG}.tar.gz"
 
           sed -i "s|url \".*\"|url \"${URL}\"|" Formula/noupling.rb

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,3 +104,17 @@ jobs:
             noupling-windows-x86_64.exe
             noupling-windows-x86_64.exe.sha256
           generate_release_notes: true
+
+      # GITHUB_TOKEN-published releases don't fire downstream workflows
+      # (release: published) by design. repository_dispatch is the documented
+      # exception that DOES chain — used here to wake homebrew.yml.
+      - name: Dispatch homebrew update
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          gh api "repos/${{ github.repository }}/dispatches" \
+            --method POST \
+            --raw-field event_type=release-published \
+            --raw-field "client_payload[tag]=${{ github.ref_name }}" \
+            --raw-field "client_payload[version]=${VERSION}"


### PR DESCRIPTION
Closes #210.

## Problem

Every release needed a manual Homebrew tap update because \`release.yml\` publishes via \`GITHUB_TOKEN\`, and GitHub Actions deliberately doesn't chain workflows from \`GITHUB_TOKEN\`-triggered \`release: published\` events. v0.7.0 hit this.

## Fix

Use \`repository_dispatch\` — the documented exception that DOES chain even when sent via \`GITHUB_TOKEN\`, with no PAT needed.

### \`release.yml\`

Adds a final step in the \`release\` job:

\`\`\`yaml
- name: Dispatch homebrew update
  env:
    GH_TOKEN: \${{ secrets.GITHUB_TOKEN }}
  run: |
    VERSION=\"\${GITHUB_REF_NAME#v}\"
    gh api \"repos/\${{ github.repository }}/dispatches\" \\
      --method POST \\
      --raw-field event_type=release-published \\
      --raw-field \"client_payload[tag]=\${{ github.ref_name }}\" \\
      --raw-field \"client_payload[version]=\${VERSION}\"
\`\`\`

### \`homebrew.yml\`

- Listens on both \`release: published\` (preserves manual UI-release path) and \`repository_dispatch: types: [release-published]\`.
- New \"Resolve tag\" step extracts tag/version from either event shape.
- Subsequent steps use \`steps.resolve.outputs.tag\` / \`.version\` instead of \`github.ref_name\`.

## Verification

- YAML structure verified locally (file size + section markers).
- Full end-to-end chain validates on the next release. The release skill at \`.claude/skills/release/SKILL.md\` will be updated to drop step 10 (manual tap update) and rely on this chain.
- If for some reason it doesn't fire, the release skill's validation step (b) catches it: \`curl raw formula | grep url\` will still show the old version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)