### PR TITLE
fix: resolve imports on segment boundary, not substring (#212)

### DIFF
--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -238,16 +238,8 @@ mod tests {
         fs::create_dir_all(&stages).unwrap();
         // `structure.py` ends with the literal string "re.py" — before the resolver
         // fix, `import re` would substring-match this file and produce a self-edge.
-        fs::write(
-            stages.join("structure.py"),
-            "import re\nimport os\n",
-        )
-        .unwrap();
-        fs::write(
-            stages.join("chords.py"),
-            "import os\n",
-        )
-        .unwrap();
+        fs::write(stages.join("structure.py"), "import re\nimport os\n").unwrap();
+        fs::write(stages.join("chords.py"), "import os\n").unwrap();
 
         let result = scan_project(dir.path(), "test-self-edge", true).unwrap();
 

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -99,6 +99,12 @@ pub fn scan_project(
                     match resolved {
                         Some(path) => {
                             let to_module = modules.iter().find(|m| m.path == path)?;
+                            // Defence in depth: a file importing itself is never a
+                            // meaningful coupling event. Drop self-edges so a future
+                            // resolver bug can't surface them as cross-module deps.
+                            if to_module.id == module.id {
+                                return None;
+                            }
                             Some(Dependency {
                                 from_module_id: module.id.clone(),
                                 to_module_id: to_module.id.clone(),
@@ -222,5 +228,43 @@ mod tests {
         let source = "use crate::foo;\nuse crate::bar;\n";
         assert!(!is_suppressed(source, 1));
         assert!(!is_suppressed(source, 2));
+    }
+
+    #[test]
+    fn stdlib_python_import_does_not_create_self_edge() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let stages = dir.path().join("src").join("stages");
+        fs::create_dir_all(&stages).unwrap();
+        // `structure.py` ends with the literal string "re.py" — before the resolver
+        // fix, `import re` would substring-match this file and produce a self-edge.
+        fs::write(
+            stages.join("structure.py"),
+            "import re\nimport os\n",
+        )
+        .unwrap();
+        fs::write(
+            stages.join("chords.py"),
+            "import os\n",
+        )
+        .unwrap();
+
+        let result = scan_project(dir.path(), "test-self-edge", true).unwrap();
+
+        let self_edges: Vec<_> = result
+            .dependencies
+            .iter()
+            .filter(|d| d.from_module_id == d.to_module_id)
+            .collect();
+        assert!(
+            self_edges.is_empty(),
+            "stdlib imports must not produce self-edges, got {:?}",
+            self_edges
+        );
+        assert!(
+            result.dependencies.is_empty(),
+            "stdlib-only imports must not produce any deps, got {:?}",
+            result.dependencies
+        );
     }
 }

--- a/src/scanner/parsers/csharp.rs
+++ b/src/scanner/parsers/csharp.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct CSharpParser;
 
@@ -79,14 +79,14 @@ fn resolve_csharp_import(import_path: &str, known_paths: &[String]) -> Option<St
 
     let file_path = segments.join("/");
     let candidate = format!("{}.cs", file_path);
-    if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
         return Some(found.clone());
     }
 
     if segments.len() > 1 {
         let parent_path = segments[..segments.len() - 1].join("/");
         let candidate = format!("{}.cs", parent_path);
-        if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/csharp.rs
+++ b/src/scanner/parsers/csharp.rs
@@ -79,14 +79,20 @@ fn resolve_csharp_import(import_path: &str, known_paths: &[String]) -> Option<St
 
     let file_path = segments.join("/");
     let candidate = format!("{}.cs", file_path);
-    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+    if let Some(found) = known_paths
+        .iter()
+        .find(|p| ends_with_segment(p, &candidate))
+    {
         return Some(found.clone());
     }
 
     if segments.len() > 1 {
         let parent_path = segments[..segments.len() - 1].join("/");
         let candidate = format!("{}.cs", parent_path);
-        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+        if let Some(found) = known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &candidate))
+        {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/dart.rs
+++ b/src/scanner/parsers/dart.rs
@@ -83,7 +83,10 @@ fn resolve_dart_import(
         let after_package = import_path.strip_prefix("package:")?;
         let after_name = after_package.split_once('/')?.1;
         let candidate = format!("lib/{}", after_name);
-        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+        if let Some(found) = known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &candidate))
+        {
             return Some(found.clone());
         }
         return known_paths

--- a/src/scanner/parsers/dart.rs
+++ b/src/scanner/parsers/dart.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct DartParser;
 
@@ -83,12 +83,12 @@ fn resolve_dart_import(
         let after_package = import_path.strip_prefix("package:")?;
         let after_name = after_package.split_once('/')?.1;
         let candidate = format!("lib/{}", after_name);
-        if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
             return Some(found.clone());
         }
         return known_paths
             .iter()
-            .find(|p| p.ends_with(after_name))
+            .find(|p| ends_with_segment(p, after_name))
             .cloned();
     }
 
@@ -96,7 +96,7 @@ fn resolve_dart_import(
     let resolved = normalize_path(&source_dir.join(import_path).to_string_lossy());
     known_paths
         .iter()
-        .find(|p| **p == resolved || p.ends_with(&resolved))
+        .find(|p| ends_with_segment(p, &resolved))
         .cloned()
 }
 

--- a/src/scanner/parsers/elixir.rs
+++ b/src/scanner/parsers/elixir.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct ElixirParser;
 
@@ -153,7 +153,7 @@ fn resolve_elixir_import(import_path: &str, known_paths: &[String]) -> Option<St
 
     for ext in &["ex", "exs"] {
         let candidate = format!("{}.{}", file_path, ext);
-        if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/elixir.rs
+++ b/src/scanner/parsers/elixir.rs
@@ -153,7 +153,10 @@ fn resolve_elixir_import(import_path: &str, known_paths: &[String]) -> Option<St
 
     for ext in &["ex", "exs"] {
         let candidate = format!("{}.{}", file_path, ext);
-        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+        if let Some(found) = known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &candidate))
+        {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/go.rs
+++ b/src/scanner/parsers/go.rs
@@ -72,7 +72,10 @@ fn resolve_go_import(import_path: &str, known_paths: &[String]) -> Option<String
         return Some(found.clone());
     }
     let candidate = format!("{}.go", import_path);
-    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+    if let Some(found) = known_paths
+        .iter()
+        .find(|p| ends_with_segment(p, &candidate))
+    {
         return Some(found.clone());
     }
     None

--- a/src/scanner/parsers/go.rs
+++ b/src/scanner/parsers/go.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct GoParser;
 
@@ -72,7 +72,7 @@ fn resolve_go_import(import_path: &str, known_paths: &[String]) -> Option<String
         return Some(found.clone());
     }
     let candidate = format!("{}.go", import_path);
-    if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
         return Some(found.clone());
     }
     None

--- a/src/scanner/parsers/haskell.rs
+++ b/src/scanner/parsers/haskell.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct HaskellParser;
 
@@ -32,7 +32,7 @@ impl LanguageParser for HaskellParser {
         let candidate = format!("{}.hs", file_path);
         known_paths
             .iter()
-            .find(|p| p.ends_with(&candidate))
+            .find(|p| ends_with_segment(p, &candidate))
             .cloned()
     }
 }

--- a/src/scanner/parsers/java.rs
+++ b/src/scanner/parsers/java.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct JavaParser;
 
@@ -80,14 +80,14 @@ fn resolve_java_import(import_path: &str, known_paths: &[String]) -> Option<Stri
 
     let file_path = segments.join("/");
     let candidate = format!("{}.java", file_path);
-    if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
         return Some(found.clone());
     }
 
     if segments.len() > 1 {
         let parent = segments[..segments.len() - 1].join("/");
         let candidate = format!("{}.java", parent);
-        if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/java.rs
+++ b/src/scanner/parsers/java.rs
@@ -80,14 +80,20 @@ fn resolve_java_import(import_path: &str, known_paths: &[String]) -> Option<Stri
 
     let file_path = segments.join("/");
     let candidate = format!("{}.java", file_path);
-    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+    if let Some(found) = known_paths
+        .iter()
+        .find(|p| ends_with_segment(p, &candidate))
+    {
         return Some(found.clone());
     }
 
     if segments.len() > 1 {
         let parent = segments[..segments.len() - 1].join("/");
         let candidate = format!("{}.java", parent);
-        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+        if let Some(found) = known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &candidate))
+        {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/kotlin.rs
+++ b/src/scanner/parsers/kotlin.rs
@@ -76,7 +76,10 @@ fn resolve_kotlin_import(import_path: &str, known_paths: &[String]) -> Option<St
     let file_path = segments.join("/");
     for ext in &["kt", "kts"] {
         let candidate = format!("{}.{}", file_path, ext);
-        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+        if let Some(found) = known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &candidate))
+        {
             return Some(found.clone());
         }
     }
@@ -85,7 +88,10 @@ fn resolve_kotlin_import(import_path: &str, known_paths: &[String]) -> Option<St
         let parent_path = segments[..segments.len() - 1].join("/");
         for ext in &["kt", "kts"] {
             let candidate = format!("{}.{}", parent_path, ext);
-            if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+            if let Some(found) = known_paths
+                .iter()
+                .find(|p| ends_with_segment(p, &candidate))
+            {
                 return Some(found.clone());
             }
         }

--- a/src/scanner/parsers/kotlin.rs
+++ b/src/scanner/parsers/kotlin.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct KotlinParser;
 
@@ -76,7 +76,7 @@ fn resolve_kotlin_import(import_path: &str, known_paths: &[String]) -> Option<St
     let file_path = segments.join("/");
     for ext in &["kt", "kts"] {
         let candidate = format!("{}.{}", file_path, ext);
-        if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
             return Some(found.clone());
         }
     }
@@ -85,7 +85,7 @@ fn resolve_kotlin_import(import_path: &str, known_paths: &[String]) -> Option<St
         let parent_path = segments[..segments.len() - 1].join("/");
         for ext in &["kt", "kts"] {
             let candidate = format!("{}.{}", parent_path, ext);
-            if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+            if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
                 return Some(found.clone());
             }
         }

--- a/src/scanner/parsers/mod.rs
+++ b/src/scanner/parsers/mod.rs
@@ -30,6 +30,17 @@ pub struct ImportEntry {
     pub line_number: i32,
 }
 
+/// True when `path` ends with `candidate` on a `/`-separated segment boundary.
+///
+/// `"foo/bar.py".ends_with("bar.py")` is true under both this helper and the
+/// stdlib `ends_with`. The difference: `"structure.py".ends_with("re.py")` is
+/// true via stdlib but false here — a path suffix has to start at a segment
+/// boundary, not at an arbitrary byte. This prevents stdlib imports like
+/// `import re` from substring-matching unrelated project files.
+pub fn ends_with_segment(path: &str, candidate: &str) -> bool {
+    path == candidate || path.ends_with(&format!("/{}", candidate))
+}
+
 /// Common interface for all language adapters.
 ///
 /// # Contract
@@ -53,6 +64,34 @@ pub trait LanguageParser: Send + Sync {
         source_file: &str,
         known_paths: &[String],
     ) -> Option<String>;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ends_with_segment;
+
+    #[test]
+    fn ends_with_segment_matches_exact_path() {
+        assert!(ends_with_segment("foo.py", "foo.py"));
+    }
+
+    #[test]
+    fn ends_with_segment_matches_slash_boundary() {
+        assert!(ends_with_segment("src/pkg/foo.py", "pkg/foo.py"));
+        assert!(ends_with_segment("src/pkg/foo.py", "foo.py"));
+    }
+
+    #[test]
+    fn ends_with_segment_rejects_mid_segment_suffix() {
+        assert!(!ends_with_segment("src/structure.py", "re.py"));
+        assert!(!ends_with_segment("src/chaos.py", "os.py"));
+        assert!(!ends_with_segment("src/figure.py", "re.py"));
+    }
+
+    #[test]
+    fn ends_with_segment_rejects_partial_segment_match() {
+        assert!(!ends_with_segment("xfoo/bar.py", "foo/bar.py"));
+    }
 }
 
 /// Maps each supported file extension to its language adapter.

--- a/src/scanner/parsers/php.rs
+++ b/src/scanner/parsers/php.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct PhpParser;
 
@@ -108,7 +108,7 @@ fn resolve_php_import(
         import_path.to_string()
     };
 
-    if let Some(found) = known_paths.iter().find(|p| p.ends_with(&as_path)) {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &as_path)) {
         return Some(found.clone());
     }
 
@@ -116,7 +116,7 @@ fn resolve_php_import(
     let resolved = normalize_path(&source_dir.join(import_path).to_string_lossy());
     known_paths
         .iter()
-        .find(|p| **p == resolved || p.ends_with(&resolved))
+        .find(|p| ends_with_segment(p, &resolved))
         .cloned()
 }
 

--- a/src/scanner/parsers/python.rs
+++ b/src/scanner/parsers/python.rs
@@ -119,11 +119,17 @@ fn resolve_python_import(
 
     let file_path = import_path.replace('.', "/");
     let candidate = format!("{}.py", file_path);
-    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+    if let Some(found) = known_paths
+        .iter()
+        .find(|p| ends_with_segment(p, &candidate))
+    {
         return Some(found.clone());
     }
     let candidate = format!("{}/__init__.py", file_path);
-    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+    if let Some(found) = known_paths
+        .iter()
+        .find(|p| ends_with_segment(p, &candidate))
+    {
         return Some(found.clone());
     }
     None
@@ -189,11 +195,8 @@ mod tests {
     #[test]
     fn python_resolver_resolves_exact_segment_match() {
         let known = vec!["src/wave2md/context.py".to_string()];
-        let result = PythonParser.resolve(
-            "wave2md.context",
-            "src/wave2md/stages/structure.py",
-            &known,
-        );
+        let result =
+            PythonParser.resolve("wave2md.context", "src/wave2md/stages/structure.py", &known);
         assert_eq!(result, Some("src/wave2md/context.py".to_string()));
     }
 }

--- a/src/scanner/parsers/python.rs
+++ b/src/scanner/parsers/python.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct PythonParser;
 
@@ -119,11 +119,11 @@ fn resolve_python_import(
 
     let file_path = import_path.replace('.', "/");
     let candidate = format!("{}.py", file_path);
-    if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
         return Some(found.clone());
     }
     let candidate = format!("{}/__init__.py", file_path);
-    if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
         return Some(found.clone());
     }
     None
@@ -162,5 +162,38 @@ mod tests {
     fn python_handles_empty_source() {
         let imports = PythonParser.parse("");
         assert!(imports.is_empty());
+    }
+
+    #[test]
+    fn python_resolver_does_not_substring_match_stdlib_with_filename_suffix() {
+        let known = vec!["src/wave2md/stages/structure.py".to_string()];
+        let result = PythonParser.resolve("re", "src/wave2md/stages/structure.py", &known);
+        assert!(
+            result.is_none(),
+            "stdlib `import re` must not substring-match structure.py, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn python_resolver_does_not_substring_match_short_stdlib_inside_filename() {
+        let known = vec!["src/chaos.py".to_string()];
+        let result = PythonParser.resolve("os", "src/main.py", &known);
+        assert!(
+            result.is_none(),
+            "`import os` must not substring-match chaos.py, got {:?}",
+            result
+        );
+    }
+
+    #[test]
+    fn python_resolver_resolves_exact_segment_match() {
+        let known = vec!["src/wave2md/context.py".to_string()];
+        let result = PythonParser.resolve(
+            "wave2md.context",
+            "src/wave2md/stages/structure.py",
+            &known,
+        );
+        assert_eq!(result, Some("src/wave2md/context.py".to_string()));
     }
 }

--- a/src/scanner/parsers/ruby.rs
+++ b/src/scanner/parsers/ruby.rs
@@ -99,10 +99,7 @@ fn resolve_ruby_import(
 
     let source_dir = Path::new(source_file).parent()?;
     let resolved = normalize_path(&source_dir.join(&with_ext).to_string_lossy());
-    if let Some(found) = known_paths
-        .iter()
-        .find(|p| ends_with_segment(p, &resolved))
-    {
+    if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &resolved)) {
         return Some(found.clone());
     }
 

--- a/src/scanner/parsers/ruby.rs
+++ b/src/scanner/parsers/ruby.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct RubyParser;
 
@@ -101,12 +101,15 @@ fn resolve_ruby_import(
     let resolved = normalize_path(&source_dir.join(&with_ext).to_string_lossy());
     if let Some(found) = known_paths
         .iter()
-        .find(|p| **p == resolved || p.ends_with(&resolved))
+        .find(|p| ends_with_segment(p, &resolved))
     {
         return Some(found.clone());
     }
 
-    known_paths.iter().find(|p| p.ends_with(&with_ext)).cloned()
+    known_paths
+        .iter()
+        .find(|p| ends_with_segment(p, &with_ext))
+        .cloned()
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────────

--- a/src/scanner/parsers/scala.rs
+++ b/src/scanner/parsers/scala.rs
@@ -73,7 +73,10 @@ fn resolve_scala_import(import_path: &str, known_paths: &[String]) -> Option<Str
 
     for ext in &["scala", "sc"] {
         let candidate = format!("{}.{}", file_path, ext);
-        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
+        if let Some(found) = known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &candidate))
+        {
             return Some(found.clone());
         }
     }

--- a/src/scanner/parsers/scala.rs
+++ b/src/scanner/parsers/scala.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct ScalaParser;
 
@@ -73,13 +73,11 @@ fn resolve_scala_import(import_path: &str, known_paths: &[String]) -> Option<Str
 
     for ext in &["scala", "sc"] {
         let candidate = format!("{}.{}", file_path, ext);
-        if let Some(found) = known_paths.iter().find(|p| p.ends_with(&candidate)) {
+        if let Some(found) = known_paths.iter().find(|p| ends_with_segment(p, &candidate)) {
             return Some(found.clone());
         }
     }
 
-    // Also try the last segment as a class name: com/example/bar/Baz.scala
-    // → already handled above since we use ends_with.
     None
 }
 

--- a/src/scanner/parsers/swift.rs
+++ b/src/scanner/parsers/swift.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser};
 
 pub struct SwiftParser;
 
@@ -29,7 +29,10 @@ impl LanguageParser for SwiftParser {
         known_paths: &[String],
     ) -> Option<String> {
         let filename = format!("{}.swift", import_path);
-        known_paths.iter().find(|p| p.ends_with(&filename)).cloned()
+        known_paths
+            .iter()
+            .find(|p| ends_with_segment(p, &filename))
+            .cloned()
     }
 }
 


### PR DESCRIPTION
## Summary

Closes #212.

- Replaces `path.ends_with(candidate)` substring matching with a new `ends_with_segment(path, candidate)` helper that anchors on `/` boundaries across 12 language resolvers.
- Adds a defence-in-depth self-edge filter at the scanner layer so any future resolver regression that produces `from == to` deps gets dropped before reaching the graph.
- Adds regression tests at three levels: helper unit tests, per-parser regression for the canonical Python case, and an end-to-end scanner test on a tempdir fixture.

## Root cause

`"structure.py".ends_with("re.py")` is `true` because byte-suffix matching doesn't respect path segment boundaries. So Python's resolver "successfully" resolved `import re` (line 3 of `stages/structure.py`) back to `structure.py` itself, producing a real `Dependency { from: structure.py, to: structure.py, line: 3 }` that then matched any `from == to` rule pattern. The same idiom was latent in 11 other parsers — `import os` colliding with `chaos.py`, `import io` with `audio.py`, and so on — silently inflating hotspot/fan-in counts.

## Files changed

- `src/scanner/parsers/mod.rs` — new `ends_with_segment` helper + 4 unit tests
- `src/scanner/parsers/{csharp,dart,elixir,go,haskell,java,kotlin,php,python,ruby,scala,swift}.rs` — swap idiom
- `src/scanner/parsers/python.rs` — 3 regression tests covering the canonical bug + the happy path
- `src/scanner/mod.rs` — self-edge guard + integration test on a synthetic `stages/structure.py + import re` fixture

## Test plan

- [x] `cargo test` → 221 unit + 5 integration tests pass
- [x] `RUSTFLAGS="-Dwarnings" cargo test` → same, no lint regressions
- [x] Pre-fix `python_resolver_does_not_substring_match_*` tests verified RED
- [x] Post-fix all tests GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)