### PR TITLE
feat: per-directory abstractness metric (Martin's A) (#69)

### DIFF
--- a/src/analyzer/abstractness.rs
+++ b/src/analyzer/abstractness.rs
@@ -1,0 +1,112 @@
+//! Per-directory abstractness: ratio of abstract type declarations
+//! (traits, interfaces, abstract classes) to all type declarations.
+//!
+//! Martin's `A = abstract_count / (abstract_count + concrete_count)`. Range
+//! 0.0 (all concrete) to 1.0 (all abstract). Combined with the instability
+//! metric, gives Distance from Main Sequence.
+
+use fxhash::FxHashMap;
+
+use crate::core::Module;
+use crate::scanner::ModuleTypeCounts;
+
+/// Abstractness metric for a directory.
+#[derive(Debug, Clone)]
+pub struct AbstractnessMetric {
+    pub dir: String,
+    pub abstract_count: usize,
+    pub concrete_count: usize,
+    /// Abstractness A = abstract_count / (abstract_count + concrete_count).
+    pub abstractness: f64,
+}
+
+/// Compute per-directory abstractness. Returns only directories that contain
+/// at least one type declaration, sorted by directory path for stable output.
+pub fn compute_abstractness(
+    modules: &[Module],
+    type_counts: &[ModuleTypeCounts],
+) -> Vec<AbstractnessMetric> {
+    let path_to_counts: FxHashMap<&str, (usize, usize)> = type_counts
+        .iter()
+        .map(|t| {
+            (
+                t.module_path.as_str(),
+                (t.counts.abstract_count, t.counts.concrete_count),
+            )
+        })
+        .collect();
+
+    let mut per_dir: FxHashMap<String, (usize, usize)> = FxHashMap::default();
+    for module in modules {
+        let Some((abstr, conc)) = path_to_counts.get(module.path.as_str()).copied() else {
+            continue;
+        };
+        let dir = std::path::Path::new(&module.path)
+            .parent()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_default();
+        if dir.is_empty() {
+            continue;
+        }
+        let entry = per_dir.entry(dir).or_default();
+        entry.0 += abstr;
+        entry.1 += conc;
+    }
+
+    let mut result: Vec<AbstractnessMetric> = per_dir
+        .into_iter()
+        .filter(|(_, (a, c))| a + c > 0)
+        .map(|(dir, (a, c))| {
+            let total = (a + c) as f64;
+            AbstractnessMetric {
+                dir,
+                abstract_count: a,
+                concrete_count: c,
+                abstractness: a as f64 / total,
+            }
+        })
+        .collect();
+    result.sort_by(|a, b| a.dir.cmp(&b.dir));
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::core::{Module, ModuleType};
+    use crate::scanner::parsers::TypeCounts;
+
+    fn file_module(path: &str) -> Module {
+        Module {
+            id: path.to_string(),
+            snapshot_id: "snap".into(),
+            parent_id: None,
+            name: std::path::Path::new(path)
+                .file_name()
+                .unwrap()
+                .to_string_lossy()
+                .into_owned(),
+            path: path.to_string(),
+            module_type: ModuleType::File,
+            depth: 1,
+        }
+    }
+
+    #[test]
+    fn aggregates_single_module_into_parent_dir() {
+        let modules = vec![file_module("src/lib.rs")];
+        let counts = vec![ModuleTypeCounts {
+            module_path: "src/lib.rs".into(),
+            counts: TypeCounts {
+                abstract_count: 1,
+                concrete_count: 2,
+            },
+        }];
+        let result = compute_abstractness(&modules, &counts);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].dir, "src");
+        assert_eq!(result[0].abstract_count, 1);
+        assert_eq!(result[0].concrete_count, 2);
+        assert!((result[0].abstractness - 1.0 / 3.0).abs() < 1e-9);
+    }
+}

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -5,6 +5,7 @@
 
 use crate::core::{Dependency, Module};
 
+mod abstractness;
 mod actions;
 mod cohesion;
 mod coupling;
@@ -22,6 +23,7 @@ mod violation_age;
 
 pub use direction::DependencyDirection;
 
+pub use abstractness::{compute_abstractness, AbstractnessMetric};
 pub use actions::compute_top_actions;
 #[allow(unused_imports)] // Public API surface: kept reachable as analyzer::TopAction
 pub use actions::TopAction;
@@ -84,6 +86,8 @@ pub struct AuditResult {
     pub external_deps: Vec<ExternalDepMetric>,
     /// Total external import count across all modules.
     pub total_external_imports: usize,
+    /// Per-directory abstractness metric (Martin's A).
+    pub abstractness: Vec<AbstractnessMetric>,
 }
 
 impl AuditResult {
@@ -254,6 +258,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
     }
 
@@ -305,6 +310,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
         red_flags: Vec::new(),
         external_deps: Vec::new(),
         total_external_imports: 0,
+        abstractness: Vec::new(),
     }
 }
 
@@ -321,9 +327,11 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
 pub fn audit_with_settings(
     modules: &[Module],
     dependencies: &[Dependency],
+    type_counts: &[crate::scanner::ModuleTypeCounts],
     settings: &crate::settings::Settings,
 ) -> AuditResult {
     let mut result = audit(modules, dependencies);
+    result.abstractness = compute_abstractness(modules, type_counts);
     result.filter_by_severity(settings.thresholds.minimum_severity);
     result.apply_coupling_mode(settings.effective_coupling_mode());
     result.apply_risk_weights(&settings.risk_weights);

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -424,7 +424,7 @@ fn audit_with_settings_matches_manual_pipeline() {
     ];
     let settings = crate::settings::Settings::default();
 
-    let auto = audit_with_settings(&modules, &deps, &settings);
+    let auto = audit_with_settings(&modules, &deps, &[], &settings);
 
     let mut manual = audit(&modules, &deps);
     manual.filter_by_severity(settings.thresholds.minimum_severity);
@@ -446,6 +446,44 @@ fn audit_with_settings_matches_manual_pipeline() {
 #[test]
 fn audit_with_settings_empty_project_scores_100() {
     let settings = crate::settings::Settings::default();
-    let result = audit_with_settings(&[], &[], &settings);
+    let result = audit_with_settings(&[], &[], &[], &settings);
     assert!((result.score - 100.0).abs() < f64::EPSILON);
+}
+
+#[test]
+fn audit_with_settings_populates_abstractness_from_type_counts() {
+    use crate::scanner::parsers::TypeCounts;
+    use crate::scanner::ModuleTypeCounts;
+
+    let modules = vec![
+        make_module("a", "src/foo.rs"),
+        make_module("b", "src/bar.rs"),
+    ];
+    let deps = vec![];
+    let type_counts = vec![
+        ModuleTypeCounts {
+            module_path: "src/foo.rs".into(),
+            counts: TypeCounts {
+                abstract_count: 1,
+                concrete_count: 0,
+            },
+        },
+        ModuleTypeCounts {
+            module_path: "src/bar.rs".into(),
+            counts: TypeCounts {
+                abstract_count: 0,
+                concrete_count: 1,
+            },
+        },
+    ];
+    let settings = crate::settings::Settings::default();
+
+    let result = audit_with_settings(&modules, &deps, &type_counts, &settings);
+
+    assert_eq!(result.abstractness.len(), 1);
+    let src = &result.abstractness[0];
+    assert_eq!(src.dir, "src");
+    assert_eq!(src.abstract_count, 1);
+    assert_eq!(src.concrete_count, 1);
+    assert!((src.abstractness - 0.5).abs() < 1e-9);
 }

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -167,6 +167,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         // Save baseline
@@ -195,6 +196,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
         assert_eq!(new, 0);
@@ -228,6 +230,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
 
@@ -256,6 +259,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 1);
@@ -290,6 +294,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
         save_baseline(dir.path(), &baseline_result).unwrap();
 
@@ -315,6 +320,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 0);

--- a/src/commands/audit.rs
+++ b/src/commands/audit.rs
@@ -78,8 +78,13 @@ pub fn run(
     }
 
     // Single-project mode (existing behavior)
-    let mut result =
-        crate::analyzer::audit_with_settings(&modules, &dependencies, &project_settings);
+    let type_counts = crate::scanner::recompute_type_counts(std::path::Path::new(path), &modules);
+    let mut result = crate::analyzer::audit_with_settings(
+        &modules,
+        &dependencies,
+        &type_counts,
+        &project_settings,
+    );
     result.rule_violations = crate::analyzer::check_dependency_rules(
         &modules,
         &dependencies,

--- a/src/commands/baseline.rs
+++ b/src/commands/baseline.rs
@@ -15,8 +15,13 @@ pub fn run(action: &str, path: &str) -> anyhow::Result<()> {
             let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
 
             let project_settings = crate::settings::Settings::load(Path::new(path))?;
-            let result =
-                crate::analyzer::audit_with_settings(&modules, &dependencies, &project_settings);
+            let type_counts = crate::scanner::recompute_type_counts(Path::new(path), &modules);
+            let result = crate::analyzer::audit_with_settings(
+                &modules,
+                &dependencies,
+                &type_counts,
+                &project_settings,
+            );
 
             crate::baseline::save_baseline(Path::new(path), &result)?;
         }

--- a/src/commands/report.rs
+++ b/src/commands/report.rs
@@ -49,8 +49,13 @@ pub fn run(
         (modules, dependencies)
     };
 
-    let mut result =
-        crate::analyzer::audit_with_settings(&report_modules, &report_deps, &project_settings);
+    let type_counts = crate::scanner::recompute_type_counts(Path::new(path), &report_modules);
+    let mut result = crate::analyzer::audit_with_settings(
+        &report_modules,
+        &report_deps,
+        &type_counts,
+        &project_settings,
+    );
     result.rule_violations = crate::analyzer::check_dependency_rules(
         &report_modules,
         &report_deps,
@@ -173,6 +178,7 @@ pub fn run(
                 let prev_result = crate::analyzer::audit_with_settings(
                     &prev_modules,
                     &prev_deps,
+                    &[],
                     &project_settings,
                 );
                 (Some(prev_result.score), Some(prev_result.violations.len()))

--- a/src/commands/trend.rs
+++ b/src/commands/trend.rs
@@ -42,8 +42,10 @@ pub fn run(path: &str, last: usize, by_module: bool) -> anyhow::Result<()> {
         let modules = module_repo.get_by_snapshot(&snap.id)?;
         let dependencies = dep_repo.get_by_snapshot(&snap.id)?;
 
+        // Historical snapshot — type counts can't be recomputed reliably from
+        // current source, so abstractness is intentionally empty in trend output.
         let result =
-            crate::analyzer::audit_with_settings(&modules, &dependencies, &project_settings);
+            crate::analyzer::audit_with_settings(&modules, &dependencies, &[], &project_settings);
 
         let delta = match prev_score {
             Some(prev) => {
@@ -103,7 +105,7 @@ fn run_by_module(
         let modules = module_repo.get_by_snapshot(&snap.id)?;
         let dependencies = dep_repo.get_by_snapshot(&snap.id)?;
 
-        let result = crate::analyzer::audit_with_settings(&modules, &dependencies, settings);
+        let result = crate::analyzer::audit_with_settings(&modules, &dependencies, &[], settings);
 
         let mut dir_severity: BTreeMap<String, f64> = BTreeMap::new();
         let mut dir_modules: BTreeMap<String, usize> = BTreeMap::new();

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -302,6 +302,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let mermaid = format_mermaid(&modules, &result);
@@ -339,6 +340,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let dot = format_dot(&modules, &result);
@@ -373,6 +375,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let mermaid = format_mermaid(&modules, &result);

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -51,6 +51,7 @@ struct ReportData {
     score_green: f64,
     score_yellow: f64,
     critical_severity: f64,
+    abstractness: Vec<crate::analyzer::AbstractnessMetric>,
 }
 
 /// Generate static HTML report files in the given output directory.
@@ -340,6 +341,7 @@ fn build_report_data(
         score_green: settings.thresholds.score_green,
         score_yellow: settings.thresholds.score_yellow,
         critical_severity: settings.thresholds.critical_severity,
+        abstractness: result.abstractness.clone(),
     }
 }
 
@@ -757,6 +759,21 @@ fn render_page(data: &ReportData, dir_path: &str) -> String {
         format!("{} - noupling Report", dir.name)
     };
 
+    // Root-page only: abstractness section (project-wide metric)
+    if is_root && !data.abstractness.is_empty() {
+        violations_html.push_str("<h2>Abstractness</h2>\n");
+        violations_html.push_str("<p class=\"section-hint\">Per-directory Martin abstractness A = abstract / (abstract + concrete). 0.0 = all concrete, 1.0 = all abstract.</p>\n");
+        violations_html.push_str("<table>\n");
+        violations_html.push_str("<tr><th>Directory</th><th class=\"center\">A</th><th class=\"center\">Abstract</th><th class=\"center\">Concrete</th></tr>\n");
+        for a in data.abstractness.iter().take(20) {
+            violations_html.push_str(&format!(
+                "<tr><td>{}</td><td class=\"center\">{:.2}</td><td class=\"center\">{}</td><td class=\"center\">{}</td></tr>\n",
+                a.dir, a.abstractness, a.abstract_count, a.concrete_count,
+            ));
+        }
+        violations_html.push_str("</table>\n");
+    }
+
     format!(
         r#"<!DOCTYPE html>
 <html lang="en">
@@ -1004,6 +1021,47 @@ mod tests {
     }
 
     #[test]
+    fn html_root_renders_abstractness_section() {
+        use crate::analyzer::AbstractnessMetric;
+        let modules = vec![make_module("a", "src/api/mod.rs")];
+        let result = AuditResult {
+            violations: vec![],
+            score: 100.0,
+            tri: 0.0,
+            total_modules: 1,
+            hotspots: Vec::new(),
+            rule_violations: Vec::new(),
+            layer_violations: Vec::new(),
+            cohesion: Vec::new(),
+            total_xs: 0,
+            independence: Vec::new(),
+            max_depth: 0,
+            critical_path: Vec::new(),
+            violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
+            suppressed_count: 0,
+            gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
+            external_deps: Vec::new(),
+            total_external_imports: 0,
+            abstractness: vec![AbstractnessMetric {
+                dir: "src/api".into(),
+                abstract_count: 2,
+                concrete_count: 3,
+                abstractness: 0.4,
+            }],
+        };
+        let dir = tempfile::tempdir().unwrap();
+        let settings = Settings::default();
+        generate_html_report(&modules, &result, "snap-x", dir.path(), &settings).unwrap();
+        let html = std::fs::read_to_string(dir.path().join("index.html")).unwrap();
+        assert!(html.contains("<h2>Abstractness</h2>"), "missing header");
+        assert!(html.contains("src/api"), "missing dir name");
+        assert!(html.contains("0.40"), "missing A value");
+    }
+
+    #[test]
     fn generates_html_files() {
         let modules = vec![
             make_module("a", "src/scanner/mod.rs"),
@@ -1030,6 +1088,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -1063,6 +1122,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -1102,6 +1162,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();
@@ -1159,6 +1220,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let dir = tempfile::tempdir().unwrap();

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -44,6 +44,7 @@ pub struct JsonReport {
     pub gravity_wells: Vec<JsonGravityWell>,
     pub red_flags: Vec<JsonRedFlag>,
     pub directory_tree: Vec<JsonDirectory>,
+    pub abstractness: Vec<JsonAbstractness>,
 }
 
 #[derive(Serialize)]
@@ -83,6 +84,14 @@ pub struct JsonHotspot {
     pub path: String,
     pub fan_in: usize,
     pub fan_out: usize,
+}
+
+#[derive(Serialize)]
+pub struct JsonAbstractness {
+    pub dir: String,
+    pub abstract_count: usize,
+    pub concrete_count: usize,
+    pub abstractness: f64,
 }
 
 #[derive(Serialize)]
@@ -282,6 +291,16 @@ impl JsonReport {
                 })
                 .collect(),
             directory_tree,
+            abstractness: result
+                .abstractness
+                .iter()
+                .map(|a| JsonAbstractness {
+                    dir: a.dir.clone(),
+                    abstract_count: a.abstract_count,
+                    concrete_count: a.concrete_count,
+                    abstractness: a.abstractness,
+                })
+                .collect(),
         }
     }
 
@@ -909,6 +928,17 @@ pub fn format_text(result: &AuditResult) -> String {
         }
     }
 
+    // Abstractness per directory
+    if !result.abstractness.is_empty() {
+        output.push_str("\nAbstractness:\n");
+        for a in result.abstractness.iter().take(10) {
+            output.push_str(&format!(
+                "  {:.2} {} ({} abstract, {} concrete)\n",
+                a.abstractness, a.dir, a.abstract_count, a.concrete_count
+            ));
+        }
+    }
+
     // Module independence
     let low_independence: Vec<_> = result
         .independence
@@ -1520,6 +1550,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-1");
@@ -1558,6 +1589,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-2");
@@ -1593,6 +1625,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let report = JsonReport::from_audit(&modules, &result, "snap-3");
@@ -1622,6 +1655,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let text = format_text(&result);
@@ -1653,11 +1687,115 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let text = format_text(&result);
         assert!(text.contains("Health Score: 100.0/100"));
         assert!(text.contains("Violations: 0"));
+    }
+
+    #[test]
+    fn json_report_includes_abstractness() {
+        use crate::analyzer::AbstractnessMetric;
+        let modules = vec![];
+        let result = AuditResult {
+            violations: vec![],
+            score: 100.0,
+            tri: 0.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+            rule_violations: Vec::new(),
+            layer_violations: Vec::new(),
+            cohesion: Vec::new(),
+            total_xs: 0,
+            independence: Vec::new(),
+            max_depth: 0,
+            critical_path: Vec::new(),
+            violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
+            suppressed_count: 0,
+            gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
+            external_deps: Vec::new(),
+            total_external_imports: 0,
+            abstractness: vec![AbstractnessMetric {
+                dir: "src/api".into(),
+                abstract_count: 1,
+                concrete_count: 4,
+                abstractness: 0.2,
+            }],
+        };
+
+        let report = JsonReport::from_audit(&modules, &result, "snap-z");
+        let json = report.to_json().unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
+        let arr = parsed["abstractness"]
+            .as_array()
+            .expect("abstractness array");
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["dir"], "src/api");
+        assert_eq!(arr[0]["abstract_count"], 1);
+        assert_eq!(arr[0]["concrete_count"], 4);
+        let a = arr[0]["abstractness"].as_f64().unwrap();
+        assert!((a - 0.2).abs() < 1e-9);
+    }
+
+    #[test]
+    fn text_format_includes_abstractness_section() {
+        use crate::analyzer::AbstractnessMetric;
+        let result = AuditResult {
+            violations: vec![],
+            score: 100.0,
+            tri: 0.0,
+            total_modules: 4,
+            hotspots: Vec::new(),
+            rule_violations: Vec::new(),
+            layer_violations: Vec::new(),
+            cohesion: Vec::new(),
+            total_xs: 0,
+            independence: Vec::new(),
+            max_depth: 0,
+            critical_path: Vec::new(),
+            violation_age: ViolationAgeSummary::default(),
+            coupling_metrics_count: 0,
+            coupling_metrics: Vec::new(),
+            suppressed_count: 0,
+            gravity_wells: Vec::new(),
+            red_flags: Vec::new(),
+            external_deps: Vec::new(),
+            total_external_imports: 0,
+            abstractness: vec![AbstractnessMetric {
+                dir: "src/api".into(),
+                abstract_count: 2,
+                concrete_count: 3,
+                abstractness: 0.4,
+            }],
+        };
+
+        let text = format_text(&result);
+        assert!(
+            text.contains("Abstractness:"),
+            "missing section header: {}",
+            text
+        );
+        assert!(text.contains("src/api"), "missing dir: {}", text);
+        assert!(
+            text.contains("0.40"),
+            "missing abstractness value: {}",
+            text
+        );
+        assert!(
+            text.contains("2 abstract"),
+            "missing abstract count: {}",
+            text
+        );
+        assert!(
+            text.contains("3 concrete"),
+            "missing concrete count: {}",
+            text
+        );
     }
 
     #[test]
@@ -1684,6 +1822,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-1");
@@ -1723,6 +1862,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-3");
@@ -1754,6 +1894,7 @@ mod tests {
             red_flags: Vec::new(),
             external_deps: Vec::new(),
             total_external_imports: 0,
+            abstractness: Vec::new(),
         };
 
         let md = _format_markdown_single(&modules, &result, "snap-4");

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -34,6 +34,15 @@ pub struct ExternalImportCount {
     pub count: usize,
 }
 
+/// Per-module count of abstract vs concrete type declarations.
+///
+/// Emitted by the scanner alongside dependencies; consumed by
+/// `analyzer::compute_abstractness` to derive per-directory abstractness.
+pub struct ModuleTypeCounts {
+    pub module_path: String,
+    pub counts: parsers::TypeCounts,
+}
+
 /// Check if an import line is suppressed by a `noupling:ignore` comment.
 /// Checks the import line itself for an inline comment, and the line above
 /// if it is a standalone comment line (starts with //, #, or --).
@@ -57,6 +66,38 @@ fn is_suppressed(source: &str, line_number: i32) -> bool {
     }
 
     false
+}
+
+/// Recompute per-module type counts for the current source files.
+///
+/// Used by commands that load modules from SQLite (which doesn't persist
+/// type counts) but need to feed abstractness analysis. Re-reads each
+/// source file and invokes the language adapter's `count_type_declarations`.
+/// Modules whose source files can't be read, or whose extension has no
+/// adapter, are silently skipped.
+pub fn recompute_type_counts(root: &Path, modules: &[Module]) -> Vec<ModuleTypeCounts> {
+    let registry = parsers::registry();
+    let ext_map: HashMap<&str, &dyn parsers::LanguageParser> = registry
+        .iter()
+        .map(|(ext, adapter)| (*ext, adapter.as_ref()))
+        .collect();
+    modules
+        .par_iter()
+        .filter_map(|m| {
+            let rel = Path::new(&m.path);
+            let ext = rel.extension().and_then(|e| e.to_str()).unwrap_or("");
+            let adapter = ext_map.get(ext)?;
+            let source = std::fs::read_to_string(root.join(rel)).ok()?;
+            let counts = adapter.count_type_declarations(&source);
+            if counts.abstract_count + counts.concrete_count == 0 {
+                return None;
+            }
+            Some(ModuleTypeCounts {
+                module_path: m.path.clone(),
+                counts,
+            })
+        })
+        .collect()
 }
 
 pub fn scan_project(
@@ -228,6 +269,25 @@ mod tests {
         let source = "use crate::foo;\nuse crate::bar;\n";
         assert!(!is_suppressed(source, 1));
         assert!(!is_suppressed(source, 2));
+    }
+
+    #[test]
+    fn recompute_type_counts_finds_rust_trait_and_struct() {
+        use std::fs;
+        let dir = tempfile::tempdir().unwrap();
+        let src = dir.path().join("src");
+        fs::create_dir_all(&src).unwrap();
+        fs::write(src.join("lib.rs"), "pub trait T {}\npub struct S {}\n").unwrap();
+
+        let result = scan_project(dir.path(), "test-types", true).unwrap();
+        let counts = recompute_type_counts(dir.path(), &result.modules);
+
+        let lib_counts = counts
+            .iter()
+            .find(|t| t.module_path.ends_with("src/lib.rs"))
+            .expect("expected type counts for src/lib.rs");
+        assert_eq!(lib_counts.counts.abstract_count, 1);
+        assert_eq!(lib_counts.counts.concrete_count, 1);
     }
 
     #[test]

--- a/src/scanner/parsers/java.rs
+++ b/src/scanner/parsers/java.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ends_with_segment, ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser, TypeCounts};
 
 pub struct JavaParser;
 
@@ -30,6 +30,54 @@ impl LanguageParser for JavaParser {
     ) -> Option<String> {
         resolve_java_import(import_path, known_paths)
     }
+
+    fn count_type_declarations(&self, source: &str) -> TypeCounts {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_java::LANGUAGE.into())
+            .expect("Failed to set Java language");
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => return TypeCounts::default(),
+        };
+        let mut counts = TypeCounts::default();
+        count_java_types(tree.root_node(), source, &mut counts);
+        counts
+    }
+}
+
+fn count_java_types(node: tree_sitter::Node, source: &str, counts: &mut TypeCounts) {
+    match node.kind() {
+        "interface_declaration" => counts.abstract_count += 1,
+        "class_declaration" => {
+            if class_has_abstract_modifier(node, source) {
+                counts.abstract_count += 1;
+            } else {
+                counts.concrete_count += 1;
+            }
+        }
+        "enum_declaration" | "record_declaration" => counts.concrete_count += 1,
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        count_java_types(child, source, counts);
+    }
+}
+
+fn class_has_abstract_modifier(node: tree_sitter::Node, source: &str) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "modifiers" {
+            let mut mcursor = child.walk();
+            for m in child.children(&mut mcursor) {
+                if &source[m.byte_range()] == "abstract" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn collect_java_imports(node: tree_sitter::Node, source: &str, imports: &mut Vec<ImportEntry>) {
@@ -105,6 +153,14 @@ fn resolve_java_import(import_path: &str, known_paths: &[String]) -> Option<Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn java_counts_interface_and_abstract_class_and_concrete_class() {
+        let source = "interface I {} abstract class A {} class C {} enum E {}";
+        let counts = JavaParser.count_type_declarations(source);
+        assert_eq!(counts.abstract_count, 2);
+        assert_eq!(counts.concrete_count, 2);
+    }
 
     #[test]
     fn java_parses_import() {

--- a/src/scanner/parsers/kotlin.rs
+++ b/src/scanner/parsers/kotlin.rs
@@ -1,6 +1,6 @@
 use tree_sitter::Parser;
 
-use super::{ends_with_segment, ImportEntry, LanguageParser};
+use super::{ends_with_segment, ImportEntry, LanguageParser, TypeCounts};
 
 pub struct KotlinParser;
 
@@ -30,6 +30,75 @@ impl LanguageParser for KotlinParser {
     ) -> Option<String> {
         resolve_kotlin_import(import_path, known_paths)
     }
+
+    fn count_type_declarations(&self, source: &str) -> TypeCounts {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_kotlin_ng::LANGUAGE.into())
+            .expect("Failed to set Kotlin language");
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => return TypeCounts::default(),
+        };
+        let mut counts = TypeCounts::default();
+        count_kotlin_types(tree.root_node(), source, &mut counts);
+        counts
+    }
+}
+
+fn count_kotlin_types(node: tree_sitter::Node, source: &str, counts: &mut TypeCounts) {
+    match node.kind() {
+        // tree-sitter-kotlin-ng folds both `interface` and `class` into
+        // `class_declaration`; the keyword child is the discriminant.
+        "class_declaration" => {
+            if kotlin_decl_is_interface(node) || kotlin_class_has_abstract_modifier(node) {
+                counts.abstract_count += 1;
+            } else {
+                counts.concrete_count += 1;
+            }
+        }
+        "object_declaration" => counts.concrete_count += 1,
+        _ => {}
+    }
+    let _ = source;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        count_kotlin_types(child, source, counts);
+    }
+}
+
+fn kotlin_decl_is_interface(node: tree_sitter::Node) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "interface" {
+            return true;
+        }
+        if child.kind() == "class" {
+            return false;
+        }
+    }
+    false
+}
+
+fn kotlin_class_has_abstract_modifier(node: tree_sitter::Node) -> bool {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "modifiers" {
+            let mut mcursor = child.walk();
+            for m in child.children(&mut mcursor) {
+                let mut sub = m.walk();
+                for inner in m.children(&mut sub) {
+                    if inner.kind() == "abstract" {
+                        return true;
+                    }
+                }
+                if m.kind() == "abstract" {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn collect_kotlin_imports(node: tree_sitter::Node, source: &str, imports: &mut Vec<ImportEntry>) {
@@ -130,6 +199,14 @@ mod tests {
         assert_eq!(imports.len(), 1);
         assert_eq!(imports[0].path, "com.example.MyClass");
         assert_eq!(imports[0].line_number, 1);
+    }
+
+    #[test]
+    fn kotlin_counts_interface_abstract_class_and_concrete_class() {
+        let source = "interface I {}\nabstract class A {}\nclass C {}\nobject O {}\n";
+        let counts = KotlinParser.count_type_declarations(source);
+        assert_eq!(counts.abstract_count, 2, "got {:?}", counts);
+        assert_eq!(counts.concrete_count, 2, "got {:?}", counts);
     }
 
     #[test]

--- a/src/scanner/parsers/mod.rs
+++ b/src/scanner/parsers/mod.rs
@@ -30,6 +30,17 @@ pub struct ImportEntry {
     pub line_number: i32,
 }
 
+/// Per-file count of abstract vs concrete type declarations.
+///
+/// Abstract = trait / interface / abstract class. Concrete = everything else
+/// that declares a named type (struct, enum, class, etc.). Used to compute the
+/// Martin abstractness metric `A = abstract / (abstract + concrete)` per directory.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TypeCounts {
+    pub abstract_count: usize,
+    pub concrete_count: usize,
+}
+
 /// True when `path` ends with `candidate` on a `/`-separated segment boundary.
 ///
 /// `"foo/bar.py".ends_with("bar.py")` is true under both this helper and the
@@ -64,6 +75,14 @@ pub trait LanguageParser: Send + Sync {
         source_file: &str,
         known_paths: &[String],
     ) -> Option<String>;
+
+    /// Count abstract vs concrete type declarations in the source.
+    ///
+    /// Default returns zeros; languages that participate in the abstractness
+    /// metric override this. See `TypeCounts`.
+    fn count_type_declarations(&self, _source: &str) -> TypeCounts {
+        TypeCounts::default()
+    }
 }
 
 #[cfg(test)]

--- a/src/scanner/parsers/rust.rs
+++ b/src/scanner/parsers/rust.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ImportEntry, LanguageParser, TypeCounts};
 
 pub struct RustParser;
 
@@ -29,6 +29,32 @@ impl LanguageParser for RustParser {
         known_paths: &[String],
     ) -> Option<String> {
         resolve_rust_import(import_path, source_file, known_paths)
+    }
+
+    fn count_type_declarations(&self, source: &str) -> TypeCounts {
+        let mut parser = Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .expect("Failed to set Rust language");
+        let tree = match parser.parse(source, None) {
+            Some(t) => t,
+            None => return TypeCounts::default(),
+        };
+        let mut counts = TypeCounts::default();
+        count_rust_types(tree.root_node(), &mut counts);
+        counts
+    }
+}
+
+fn count_rust_types(node: tree_sitter::Node, counts: &mut TypeCounts) {
+    match node.kind() {
+        "trait_item" => counts.abstract_count += 1,
+        "struct_item" | "enum_item" | "union_item" => counts.concrete_count += 1,
+        _ => {}
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        count_rust_types(child, counts);
     }
 }
 
@@ -295,6 +321,14 @@ mod tests {
     }
 
     // Parser tests
+
+    #[test]
+    fn counts_one_trait_one_struct() {
+        let source = "pub trait T {}\npub struct S {}\n";
+        let counts = RustParser.count_type_declarations(source);
+        assert_eq!(counts.abstract_count, 1);
+        assert_eq!(counts.concrete_count, 1);
+    }
 
     #[test]
     fn parses_simple_use() {

--- a/src/scanner/parsers/typescript.rs
+++ b/src/scanner/parsers/typescript.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 use tree_sitter::Parser;
 
-use super::{ImportEntry, LanguageParser};
+use super::{ImportEntry, LanguageParser, TypeCounts};
 
 /// TypeScript adapter (`.ts` files).
 pub struct TypeScriptParser;
@@ -22,6 +22,10 @@ impl LanguageParser for TypeScriptParser {
     ) -> Option<String> {
         resolve_typescript_import(import_path, source_file, known_paths)
     }
+
+    fn count_type_declarations(&self, source: &str) -> TypeCounts {
+        count_typescript_types(source, false)
+    }
 }
 
 impl LanguageParser for TsxParser {
@@ -36,6 +40,44 @@ impl LanguageParser for TsxParser {
         known_paths: &[String],
     ) -> Option<String> {
         resolve_typescript_import(import_path, source_file, known_paths)
+    }
+
+    fn count_type_declarations(&self, source: &str) -> TypeCounts {
+        count_typescript_types(source, true)
+    }
+}
+
+fn count_typescript_types(source: &str, tsx: bool) -> TypeCounts {
+    let mut parser = Parser::new();
+    let lang: tree_sitter::Language = if tsx {
+        tree_sitter_typescript::LANGUAGE_TSX.into()
+    } else {
+        tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()
+    };
+    parser
+        .set_language(&lang)
+        .expect("Failed to set TypeScript language");
+    let tree = match parser.parse(source, None) {
+        Some(t) => t,
+        None => return TypeCounts::default(),
+    };
+    let mut counts = TypeCounts::default();
+    count_ts_types(tree.root_node(), source, &mut counts);
+    counts
+}
+
+fn count_ts_types(node: tree_sitter::Node, source: &str, counts: &mut TypeCounts) {
+    match node.kind() {
+        "interface_declaration" => counts.abstract_count += 1,
+        "abstract_class_declaration" => counts.abstract_count += 1,
+        "class_declaration" => counts.concrete_count += 1,
+        "enum_declaration" => counts.concrete_count += 1,
+        _ => {}
+    }
+    let _ = source;
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        count_ts_types(child, source, counts);
     }
 }
 
@@ -221,6 +263,22 @@ mod tests {
         let paths = ts_paths();
         let result = TypeScriptParser.resolve("./helpers", "src/utils/helpers.ts", &paths);
         assert_eq!(result, Some("src/utils/helpers.ts".to_string()));
+    }
+
+    #[test]
+    fn ts_counts_interface_abstract_class_and_concrete_class() {
+        let source = "interface I {}\nabstract class A {}\nclass C {}\nenum E {}\n";
+        let counts = TypeScriptParser.count_type_declarations(source);
+        assert_eq!(counts.abstract_count, 2, "got {:?}", counts);
+        assert_eq!(counts.concrete_count, 2, "got {:?}", counts);
+    }
+
+    #[test]
+    fn tsx_counts_match_ts_counts() {
+        let source = "interface I {}\nabstract class A {}\nclass C {}\n";
+        let counts = TsxParser.count_type_declarations(source);
+        assert_eq!(counts.abstract_count, 2);
+        assert_eq!(counts.concrete_count, 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Closes #69.

Adds the abstractness metric `A = abstract / (abstract + concrete)` per directory, derived from counts of `trait` / `interface` / `abstract class` declarations (abstract) versus `struct` / `enum` / `class` declarations (concrete). Wired end-to-end through scanner → analyzer → text/JSON/HTML reports.

## Slicing

Built as 8 tracer-bullet slices, each a RED → GREEN cycle:

1. Rust trait detection (`count_type_declarations` trait method + Rust impl)
2. Per-directory aggregation (`analyzer::abstractness`)
3. Scanner → AuditResult wiring (`recompute_type_counts` helper, `audit_with_settings` signature)
4. Text report output (`Abstractness:` section)
5. Java parser (interface, abstract class, record)
6. Kotlin parser (interface and abstract class via tree-sitter-kotlin-ng's folded `class_declaration`)
7. TypeScript + TSX parser (interface, abstract class, enum)
8. JSON report (`abstractness` array) + HTML (root-page table)

## Design notes

- **In-memory only** — no SQLite schema change. Counts are recomputed from current source files at audit time via `scanner::recompute_type_counts`. Historical trend snapshots intentionally skip abstractness (their source can't be reconstructed reliably). Persistence is the natural follow-up if snapshot-over-snapshot abstractness trends are wanted later.
- **Counting rules** are literal per Martin: only `trait` / `interface` / `abstract class` count as abstract. Sealed classes, type aliases, etc. stay concrete; the metric is meant as a starting point, not an exhaustive taxonomy.
- **Trait method default** returns `TypeCounts::default()`, so the 12 non-participating language parsers compile unchanged.

## Files changed

- `src/scanner/parsers/mod.rs` — `TypeCounts` struct + `count_type_declarations` trait method
- `src/scanner/parsers/{rust,java,kotlin,typescript}.rs` — language implementations
- `src/scanner/mod.rs` — `ModuleTypeCounts` + `recompute_type_counts` helper
- `src/analyzer/abstractness.rs` — new aggregator (mirrors `cohesion.rs`)
- `src/analyzer/mod.rs` — `AuditResult.abstractness` field, `audit_with_settings` signature
- `src/commands/{audit,baseline,report,trend}.rs` — 7 call sites updated
- `src/reporter/{mod,html}.rs` — text + JSON + HTML rendering

## Test plan

- [x] 232 unit + 5 integration tests pass with `RUSTFLAGS=-Dwarnings`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] Each slice has a regression test that was verified RED before implementation went in
- [x] Kotlin grammar shape probed and locked (`class_declaration` covers both `class` and `interface`)
- [x] TSX uses the TSX grammar variant, not the TS one (caught during slice 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)