### PR TITLE
refactor: layer fix + AuditResult builder + LayerIndex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **`TypeCounts` and `ModuleTypeCounts` moved to `core`**: The abstractness work in #215 introduced 4 layer violations by importing scanner-layer types into the analyzer layer. Moved both types to `core::{TypeCounts, ModuleTypeCounts}` so the analyzer can consume them without crossing layers. `scanner::parsers::TypeCounts` and `scanner::ModuleTypeCounts` remain available as re-exports. Brings the project's own health score back to 100/100.
+- **`AuditResultBuilder` for test construction**: New test-only builder in `analyzer/mod.rs` with `with_*` methods and sensible defaults (empty vecs, `score: 100.0`). Existing tests construct ~25-field literals by hand; the builder lets each test specify only what it asserts on. Converted ~37 sites across `baseline.rs`, `reporter/{mod,html,graph}.rs`. The per-new-metric test-fixture tax (which was ~20 mechanical edits in #215 and #217) drops to one default in the builder.
+- **`LayerIndex` consolidates layer-pattern matching**: `check_layer_rules`, `AuditResult::filter_by_layers`, and `AuditResult::apply_layer_weights` each previously compiled their own glob matchers and walked them independently. They now share a single `LayerIndex` in `analyzer/layers.rs` that compiles globs once and answers `layer_of(path)`. Also drops a `pattern.contains(extract_dir(path))` substring-fallback in `apply_layer_weights` that wasn't matched by any test and didn't have a documented use case.
 - **`llms.txt` moved from repo root to `docs/llms.txt`**: GitHub Pages is configured to serve from `main:/docs`, so the file at the repo root wasn't reachable at the spec-defined URL `https://pererikbergman.github.io/noupling/llms.txt` (returned 404). Moving it into `docs/` makes it accessible at that canonical URL, which is where LLM tooling probes per the [llmstxt.org](https://llmstxt.org) convention.
 
 ### Fixed

--- a/src/analyzer/abstractness.rs
+++ b/src/analyzer/abstractness.rs
@@ -8,7 +8,7 @@
 use fxhash::FxHashMap;
 
 use crate::core::Module;
-use crate::scanner::ModuleTypeCounts;
+use crate::core::ModuleTypeCounts;
 
 /// Abstractness metric for a directory.
 #[derive(Debug, Clone)]
@@ -73,8 +73,8 @@ pub fn compute_abstractness(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::core::TypeCounts;
     use crate::core::{Module, ModuleType};
-    use crate::scanner::parsers::TypeCounts;
 
     fn file_module(path: &str) -> Module {
         Module {

--- a/src/analyzer/layers.rs
+++ b/src/analyzer/layers.rs
@@ -7,6 +7,43 @@ use super::AuditResult;
 use super::DependencyDirection;
 use crate::core::{Dependency, Module};
 
+/// Compiled layer-pattern index. Holds one `GlobMatcher` per layer (in their
+/// configured order) and answers "which layer is this path in?" without
+/// recompiling globs on every call.
+///
+/// Existed because `check_layer_rules`, `AuditResult::filter_by_layers`, and
+/// `AuditResult::apply_layer_weights` previously each compiled their own
+/// matcher vec and walked it independently. Now there is one place to fix a
+/// layer-matching bug or change the resolution rule.
+pub(super) struct LayerIndex<'a> {
+    matchers: Vec<(usize, &'a str, globset::GlobMatcher)>,
+}
+
+impl<'a> LayerIndex<'a> {
+    pub(super) fn new(layers: &'a [crate::settings::Layer]) -> Self {
+        let matchers = layers
+            .iter()
+            .enumerate()
+            .filter_map(|(i, l)| {
+                globset::Glob::new(&l.pattern)
+                    .ok()
+                    .map(|g| (i, l.name.as_str(), g.compile_matcher()))
+            })
+            .collect();
+        LayerIndex { matchers }
+    }
+
+    /// First layer whose pattern matches `path`, or `None`.
+    pub(super) fn layer_of(&self, path: &str) -> Option<(usize, &'a str)> {
+        for (idx, name, matcher) in &self.matchers {
+            if matcher.is_match(path) {
+                return Some((*idx, name));
+            }
+        }
+        None
+    }
+}
+
 /// A violation of architectural layer ordering.
 #[derive(Debug, Clone)]
 pub struct LayerViolation {
@@ -33,30 +70,17 @@ pub fn check_layer_rules(
         return Vec::new();
     }
 
-    // Build glob matchers for each layer
-    let layer_matchers: Vec<(usize, &str, globset::GlobMatcher)> = layers
-        .iter()
-        .enumerate()
-        .filter_map(|(i, l)| {
-            globset::Glob::new(&l.pattern)
-                .ok()
-                .map(|g| (i, l.name.as_str(), g.compile_matcher()))
-        })
-        .collect();
+    let index = LayerIndex::new(layers);
 
     let id_to_path: FxHashMap<&str, &str> = modules
         .iter()
         .map(|m| (m.id.as_str(), m.path.as_str()))
         .collect();
 
-    // Assign each module to a layer (first matching pattern wins)
     let mut module_layer: FxHashMap<&str, (usize, &str)> = FxHashMap::default();
     for module in modules {
-        for (idx, name, matcher) in &layer_matchers {
-            if matcher.is_match(&module.path) {
-                module_layer.insert(module.id.as_str(), (*idx, name));
-                break;
-            }
+        if let Some(layer) = index.layer_of(&module.path) {
+            module_layer.insert(module.id.as_str(), layer);
         }
     }
 
@@ -97,25 +121,7 @@ impl AuditResult {
             return;
         }
 
-        // Build layer matchers and index
-        let layer_matchers: Vec<(usize, globset::GlobMatcher)> = layers
-            .iter()
-            .enumerate()
-            .filter_map(|(i, l)| {
-                globset::Glob::new(&l.pattern)
-                    .ok()
-                    .map(|g| (i, g.compile_matcher()))
-            })
-            .collect();
-
-        let get_layer = |path: &str| -> Option<usize> {
-            for (idx, matcher) in &layer_matchers {
-                if matcher.is_match(path) {
-                    return Some(*idx);
-                }
-            }
-            None
-        };
+        let index = LayerIndex::new(layers);
 
         self.violations.retain(|v| {
             // Always keep circular violations
@@ -123,13 +129,13 @@ impl AuditResult {
                 return true;
             }
 
-            let from_layer = get_layer(&v.from_module);
-            let to_layer = get_layer(&v.to_module);
+            let from_idx = index.layer_of(&v.from_module).map(|(i, _)| i);
+            let to_idx = index.layer_of(&v.to_module).map(|(i, _)| i);
 
-            match (from_layer, to_layer) {
+            match (from_idx, to_idx) {
                 // Both have layers: suppress downward deps (from_idx < to_idx)
                 // Keep: same layer (from_idx == to_idx) or upward (from_idx > to_idx)
-                (Some(from_idx), Some(to_idx)) => from_idx >= to_idx,
+                (Some(from), Some(to)) => from >= to,
                 // One or both unassigned: keep the violation
                 _ => true,
             }
@@ -144,34 +150,8 @@ impl AuditResult {
         if layers.is_empty() {
             return;
         }
-        let matchers: Vec<_> = layers
-            .iter()
-            .filter_map(|l| {
-                globset::Glob::new(&l.pattern)
-                    .ok()
-                    .and_then(|g| g.compile_matcher().into())
-            })
-            .collect();
 
-        fn find_layer_idx(
-            path: &str,
-            layers: &[crate::settings::Layer],
-            matchers: &[globset::GlobMatcher],
-        ) -> Option<usize> {
-            for (i, matcher) in matchers.iter().enumerate() {
-                if matcher.is_match(path) || layers[i].pattern.contains(&extract_dir(path)) {
-                    return Some(i);
-                }
-            }
-            None
-        }
-
-        fn extract_dir(path: &str) -> String {
-            std::path::Path::new(path)
-                .parent()
-                .map(|p| p.to_string_lossy().to_string())
-                .unwrap_or_default()
-        }
+        let index = LayerIndex::new(layers);
 
         // Adjust sibling violations in allow_sibling layers
         for v in self
@@ -182,8 +162,8 @@ impl AuditResult {
             if v.direction != DependencyDirection::Sibling {
                 continue;
             }
-            let from_layer = find_layer_idx(&v.from_module, layers, &matchers);
-            let to_layer = find_layer_idx(&v.to_module, layers, &matchers);
+            let from_layer = index.layer_of(&v.from_module).map(|(i, _)| i);
+            let to_layer = index.layer_of(&v.to_module).map(|(i, _)| i);
 
             // Both in the same layer that allows siblings → reduced weight
             if let (Some(fi), Some(ti)) = (from_layer, to_layer) {

--- a/src/analyzer/mod.rs
+++ b/src/analyzer/mod.rs
@@ -100,6 +100,139 @@ pub struct AuditResult {
     pub stability_violations: Vec<StabilityViolation>,
 }
 
+/// Test-only builder for `AuditResult` with sensible defaults.
+///
+/// Existed because the production type has ~25 fields and tests historically had
+/// to spell out every single one even when asserting on one or two. Use `with_*`
+/// to override just what the test cares about.
+#[cfg(test)]
+pub(crate) struct AuditResultBuilder {
+    inner: AuditResult,
+}
+
+#[cfg(test)]
+#[allow(dead_code)] // most setters are exercised across the crate's test modules
+impl AuditResultBuilder {
+    pub(crate) fn new() -> Self {
+        Self {
+            inner: AuditResult {
+                violations: Vec::new(),
+                score: 100.0,
+                tri: 0.0,
+                total_modules: 0,
+                hotspots: Vec::new(),
+                rule_violations: Vec::new(),
+                layer_violations: Vec::new(),
+                cohesion: Vec::new(),
+                total_xs: 0,
+                independence: Vec::new(),
+                max_depth: 0,
+                critical_path: Vec::new(),
+                violation_age: ViolationAgeSummary::default(),
+                coupling_metrics_count: 0,
+                coupling_metrics: Vec::new(),
+                suppressed_count: 0,
+                gravity_wells: Vec::new(),
+                red_flags: Vec::new(),
+                external_deps: Vec::new(),
+                total_external_imports: 0,
+                abstractness: Vec::new(),
+                instability: Vec::new(),
+                stability_violations: Vec::new(),
+            },
+        }
+    }
+
+    pub(crate) fn with_score(mut self, score: f64) -> Self {
+        self.inner.score = score;
+        self
+    }
+    pub(crate) fn with_tri(mut self, tri: f64) -> Self {
+        self.inner.tri = tri;
+        self
+    }
+    pub(crate) fn with_total_modules(mut self, n: usize) -> Self {
+        self.inner.total_modules = n;
+        self
+    }
+    pub(crate) fn with_total_xs(mut self, n: usize) -> Self {
+        self.inner.total_xs = n;
+        self
+    }
+    pub(crate) fn with_max_depth(mut self, n: usize) -> Self {
+        self.inner.max_depth = n;
+        self
+    }
+    pub(crate) fn with_suppressed_count(mut self, n: usize) -> Self {
+        self.inner.suppressed_count = n;
+        self
+    }
+    pub(crate) fn with_total_external_imports(mut self, n: usize) -> Self {
+        self.inner.total_external_imports = n;
+        self
+    }
+    pub(crate) fn with_violations(mut self, v: Vec<CouplingViolation>) -> Self {
+        self.inner.violations = v;
+        self
+    }
+    pub(crate) fn with_hotspots(mut self, v: Vec<ModuleMetrics>) -> Self {
+        self.inner.hotspots = v;
+        self
+    }
+    pub(crate) fn with_rule_violations(mut self, v: Vec<RuleViolation>) -> Self {
+        self.inner.rule_violations = v;
+        self
+    }
+    pub(crate) fn with_layer_violations(mut self, v: Vec<LayerViolation>) -> Self {
+        self.inner.layer_violations = v;
+        self
+    }
+    pub(crate) fn with_cohesion(mut self, v: Vec<CohesionMetrics>) -> Self {
+        self.inner.cohesion = v;
+        self
+    }
+    pub(crate) fn with_independence(mut self, v: Vec<ModuleIndependence>) -> Self {
+        self.inner.independence = v;
+        self
+    }
+    pub(crate) fn with_critical_path(mut self, v: Vec<String>) -> Self {
+        self.inner.critical_path = v;
+        self
+    }
+    pub(crate) fn with_coupling_metrics(mut self, v: Vec<CouplingViolation>) -> Self {
+        self.inner.coupling_metrics_count = v.len();
+        self.inner.coupling_metrics = v;
+        self
+    }
+    pub(crate) fn with_gravity_wells(mut self, v: Vec<GravityWell>) -> Self {
+        self.inner.gravity_wells = v;
+        self
+    }
+    pub(crate) fn with_red_flags(mut self, v: Vec<RedFlag>) -> Self {
+        self.inner.red_flags = v;
+        self
+    }
+    pub(crate) fn with_external_deps(mut self, v: Vec<ExternalDepMetric>) -> Self {
+        self.inner.external_deps = v;
+        self
+    }
+    pub(crate) fn with_abstractness(mut self, v: Vec<AbstractnessMetric>) -> Self {
+        self.inner.abstractness = v;
+        self
+    }
+    pub(crate) fn with_instability(mut self, v: Vec<InstabilityMetric>) -> Self {
+        self.inner.instability = v;
+        self
+    }
+    pub(crate) fn with_stability_violations(mut self, v: Vec<StabilityViolation>) -> Self {
+        self.inner.stability_violations = v;
+        self
+    }
+    pub(crate) fn build(self) -> AuditResult {
+        self.inner
+    }
+}
+
 impl AuditResult {
     /// Keep only violations involving at least one changed file and recalculate the score.
     pub fn filter_by_changed_files(&mut self, changed_files: &[String]) {
@@ -344,7 +477,7 @@ pub fn audit(modules: &[Module], dependencies: &[Dependency]) -> AuditResult {
 pub fn audit_with_settings(
     modules: &[Module],
     dependencies: &[Dependency],
-    type_counts: &[crate::scanner::ModuleTypeCounts],
+    type_counts: &[crate::core::ModuleTypeCounts],
     settings: &crate::settings::Settings,
 ) -> AuditResult {
     let mut result = audit(modules, dependencies);

--- a/src/analyzer/tests.rs
+++ b/src/analyzer/tests.rs
@@ -481,8 +481,7 @@ fn audit_populates_per_directory_instability() {
 
 #[test]
 fn audit_with_settings_populates_abstractness_from_type_counts() {
-    use crate::scanner::parsers::TypeCounts;
-    use crate::scanner::ModuleTypeCounts;
+    use crate::core::{ModuleTypeCounts, TypeCounts};
 
     let modules = vec![
         make_module("a", "src/foo.rs"),

--- a/src/baseline.rs
+++ b/src/baseline.rs
@@ -113,8 +113,7 @@ fn chrono_now() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analyzer::DependencyDirection;
-    use crate::analyzer::ViolationAgeSummary;
+    use crate::analyzer::{AuditResultBuilder, DependencyDirection};
 
     fn make_coupling(from: &str, to: &str) -> CouplingViolation {
         CouplingViolation {
@@ -146,62 +145,28 @@ mod tests {
         // Create a fake history.db so find_db doesn't fail
         std::fs::write(noupling_dir.join("history.db"), "").unwrap();
 
-        let result = AuditResult {
-            violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
-            score: 50.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![
+                make_coupling("a.rs", "b.rs"),
+                make_coupling("c.rs", "d.rs"),
+            ])
+            .with_score(50.0)
+            .with_total_modules(4)
+            .build();
 
         // Save baseline
         save_baseline(dir.path(), &result).unwrap();
         assert!(dir.path().join(".noupling/baseline.json").exists());
 
         // Same violations = all existing, none new
-        let mut same_result = AuditResult {
-            violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
-            score: 50.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let mut same_result = AuditResultBuilder::new()
+            .with_violations(vec![
+                make_coupling("a.rs", "b.rs"),
+                make_coupling("c.rs", "d.rs"),
+            ])
+            .with_score(50.0)
+            .with_total_modules(4)
+            .build();
         let (new, resolved) = compare_baseline(dir.path(), &mut same_result).unwrap();
         assert_eq!(new, 0);
         assert_eq!(resolved, 0);
@@ -213,62 +178,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join(".noupling")).unwrap();
 
-        let baseline_result = AuditResult {
-            violations: vec![make_coupling("a.rs", "b.rs")],
-            score: 75.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let baseline_result = AuditResultBuilder::new()
+            .with_violations(vec![make_coupling("a.rs", "b.rs")])
+            .with_score(75.0)
+            .with_total_modules(4)
+            .build();
         save_baseline(dir.path(), &baseline_result).unwrap();
 
         // New violation added
-        let mut current = AuditResult {
-            violations: vec![
+        let mut current = AuditResultBuilder::new()
+            .with_violations(vec![
                 make_coupling("a.rs", "b.rs"), // existing
                 make_coupling("x.rs", "y.rs"), // new
-            ],
-            score: 50.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+            ])
+            .with_score(50.0)
+            .with_total_modules(4)
+            .build();
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 1);
         assert_eq!(resolved, 0);
@@ -281,59 +206,22 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join(".noupling")).unwrap();
 
-        let baseline_result = AuditResult {
-            violations: vec![make_coupling("a.rs", "b.rs"), make_coupling("c.rs", "d.rs")],
-            score: 50.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let baseline_result = AuditResultBuilder::new()
+            .with_violations(vec![
+                make_coupling("a.rs", "b.rs"),
+                make_coupling("c.rs", "d.rs"),
+            ])
+            .with_score(50.0)
+            .with_total_modules(4)
+            .build();
         save_baseline(dir.path(), &baseline_result).unwrap();
 
         // One violation resolved
-        let mut current = AuditResult {
-            violations: vec![make_coupling("a.rs", "b.rs")],
-            score: 75.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let mut current = AuditResultBuilder::new()
+            .with_violations(vec![make_coupling("a.rs", "b.rs")])
+            .with_score(75.0)
+            .with_total_modules(4)
+            .build();
         let (new, resolved) = compare_baseline(dir.path(), &mut current).unwrap();
         assert_eq!(new, 0);
         assert_eq!(resolved, 1);

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -47,6 +47,25 @@ pub struct Dependency {
     pub line_number: i32,
 }
 
+/// Per-file count of abstract vs concrete type declarations.
+///
+/// Abstract = trait / interface / abstract class. Concrete = everything else
+/// that declares a named type (struct, enum, class, etc.). Lives in `core`
+/// because it's a shared data shape consumed by both `scanner` (producer)
+/// and `analyzer` (consumer) — placing it in either crosses a layer.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct TypeCounts {
+    pub abstract_count: usize,
+    pub concrete_count: usize,
+}
+
+/// Per-module pairing of a file path with its `TypeCounts`. Produced by
+/// `scanner::recompute_type_counts`, consumed by `analyzer::compute_abstractness`.
+pub struct ModuleTypeCounts {
+    pub module_path: String,
+    pub counts: TypeCounts,
+}
+
 /// A point-in-time scan of a project.
 ///
 /// Each scan creates a new snapshot with a unique ID, allowing

--- a/src/reporter/graph.rs
+++ b/src/reporter/graph.rs
@@ -234,7 +234,7 @@ fn sanitize(name: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analyzer::ViolationAgeSummary;
+    use crate::analyzer::AuditResultBuilder;
     use crate::core::ModuleType;
 
     fn make_module(path: &str) -> Module {
@@ -281,31 +281,11 @@ mod tests {
             make_module("src/scanner/mod.rs"),
             make_module("src/core/mod.rs"),
         ];
-        let result = AuditResult {
-            violations: vec![make_violation("src/scanner", "src/core")],
-            score: 75.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![make_violation("src/scanner", "src/core")])
+            .with_score(75.0)
+            .with_total_modules(2)
+            .build();
 
         let mermaid = format_mermaid(&modules, &result);
         assert!(mermaid.contains("flowchart LR"));
@@ -321,31 +301,11 @@ mod tests {
             make_module("src/scanner/mod.rs"),
             make_module("src/core/mod.rs"),
         ];
-        let result = AuditResult {
-            violations: vec![make_violation("src/scanner", "src/core")],
-            score: 75.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![make_violation("src/scanner", "src/core")])
+            .with_score(75.0)
+            .with_total_modules(2)
+            .build();
 
         let dot = format_dot(&modules, &result);
         assert!(dot.contains("digraph noupling"));
@@ -358,31 +318,7 @@ mod tests {
     #[test]
     fn empty_violations_still_generates() {
         let modules = vec![make_module("src/scanner/mod.rs")];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 1,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(1).build();
 
         let mermaid = format_mermaid(&modules, &result);
         assert!(mermaid.contains("flowchart LR"));

--- a/src/reporter/html.rs
+++ b/src/reporter/html.rs
@@ -1033,8 +1033,8 @@ fn build_breadcrumbs(current_path: &str, root_path: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::analyzer::AuditResultBuilder;
     use crate::analyzer::CouplingViolation;
-    use crate::analyzer::ViolationAgeSummary;
     use crate::core::ModuleType;
 
     fn make_module(id: &str, path: &str) -> Module {
@@ -1057,36 +1057,15 @@ mod tests {
     fn html_root_renders_stability_violations_section() {
         use crate::analyzer::StabilityViolation;
         let modules = vec![make_module("a", "src/api/mod.rs")];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 1,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: vec![StabilityViolation {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(1)
+            .with_stability_violations(vec![StabilityViolation {
                 from_dir: "src/stable".into(),
                 to_dir: "src/unstable".into(),
                 from_instability: 0.17,
                 to_instability: 0.83,
-            }],
-        };
+            }])
+            .build();
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();
         generate_html_report(&modules, &result, "snap-sv", dir.path(), &settings).unwrap();
@@ -1103,36 +1082,15 @@ mod tests {
             make_module("a", "src/app/main.rs"),
             make_module("b", "src/core/lib.rs"),
         ];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: vec![InstabilityMetric {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(2)
+            .with_instability(vec![InstabilityMetric {
                 dir: "src/app".into(),
                 ca: 0,
                 ce: 1,
                 instability: 1.0,
-            }],
-            stability_violations: Vec::new(),
-        };
+            }])
+            .build();
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();
         generate_html_report(&modules, &result, "snap-i", dir.path(), &settings).unwrap();
@@ -1149,36 +1107,15 @@ mod tests {
     fn html_root_renders_abstractness_section() {
         use crate::analyzer::AbstractnessMetric;
         let modules = vec![make_module("a", "src/api/mod.rs")];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 1,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: vec![AbstractnessMetric {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(1)
+            .with_abstractness(vec![AbstractnessMetric {
                 dir: "src/api".into(),
                 abstract_count: 2,
                 concrete_count: 3,
                 abstractness: 0.4,
-            }],
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+            }])
+            .build();
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();
         generate_html_report(&modules, &result, "snap-x", dir.path(), &settings).unwrap();
@@ -1194,31 +1131,7 @@ mod tests {
             make_module("a", "src/scanner/mod.rs"),
             make_module("b", "src/storage/mod.rs"),
         ];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(2).build();
 
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();
@@ -1230,31 +1143,10 @@ mod tests {
     #[test]
     fn html_contains_score() {
         let modules = vec![make_module("a", "src/mod.rs")];
-        let result = AuditResult {
-            violations: vec![],
-            score: 95.5,
-            tri: 0.0,
-            total_modules: 1,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_score(95.5)
+            .with_total_modules(1)
+            .build();
 
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();
@@ -1272,31 +1164,7 @@ mod tests {
             make_module("b", "src/scanner/resolver.rs"),
             make_module("c", "src/storage/db.rs"),
         ];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 3,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(3).build();
 
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();
@@ -1314,8 +1182,8 @@ mod tests {
             make_module("a", "src/scanner/mod.rs"),
             make_module("b", "src/storage/mod.rs"),
         ];
-        let result = AuditResult {
-            violations: vec![CouplingViolation {
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![CouplingViolation {
                 dir_a: "src/scanner".to_string(),
                 dir_b: "src/storage".to_string(),
                 from_module: "src/scanner/mod.rs".to_string(),
@@ -1333,30 +1201,10 @@ mod tests {
                 break_cost: 0,
                 line_number: 0,
                 weight: 0,
-            }],
-            score: 75.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+            }])
+            .with_score(75.0)
+            .with_total_modules(2)
+            .build();
 
         let dir = tempfile::tempdir().unwrap();
         let settings = Settings::default();

--- a/src/reporter/mod.rs
+++ b/src/reporter/mod.rs
@@ -1564,7 +1564,7 @@ fn _format_markdown_single(modules: &[Module], result: &AuditResult, snapshot_id
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::analyzer::ViolationAgeSummary;
+    use crate::analyzer::AuditResultBuilder;
 
     fn make_violation(from: &str, to: &str, severity: f64, depth: i32) -> CouplingViolation {
         CouplingViolation {
@@ -1591,31 +1591,11 @@ mod tests {
     #[test]
     fn json_report_has_required_fields() {
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![make_violation("a.rs", "b.rs", 1.0, 0)],
-            score: 50.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![make_violation("a.rs", "b.rs", 1.0, 0)])
+            .with_score(50.0)
+            .with_total_modules(2)
+            .build();
 
         let report = JsonReport::from_audit(&modules, &result, "snap-1");
         let json = report.to_json().unwrap();
@@ -1632,31 +1612,7 @@ mod tests {
     #[test]
     fn json_report_valid_json() {
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 5,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(5).build();
 
         let report = JsonReport::from_audit(&modules, &result, "snap-2");
         let json = report.to_json().unwrap();
@@ -1666,35 +1622,15 @@ mod tests {
     #[test]
     fn critical_violations_counts_high_severity() {
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![
                 make_violation("a.rs", "b.rs", 1.0, 0),
                 make_violation("c.rs", "d.rs", 0.5, 1),
                 make_violation("e.rs", "f.rs", 0.25, 2),
-            ],
-            score: 42.0,
-            tri: 0.0,
-            total_modules: 6,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+            ])
+            .with_score(42.0)
+            .with_total_modules(6)
+            .build();
 
         let report = JsonReport::from_audit(&modules, &result, "snap-3");
         assert_eq!(report.critical_violations, 2);
@@ -1702,31 +1638,16 @@ mod tests {
 
     #[test]
     fn text_format_shows_score_and_violations() {
-        let result = AuditResult {
-            violations: vec![make_violation("scanner/mod.rs", "storage/mod.rs", 0.5, 1)],
-            score: 75.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![make_violation(
+                "scanner/mod.rs",
+                "storage/mod.rs",
+                0.5,
+                1,
+            )])
+            .with_score(75.0)
+            .with_total_modules(4)
+            .build();
 
         let text = format_text(&result);
         assert!(text.contains("Health Score: 75.0/100"));
@@ -1736,31 +1657,7 @@ mod tests {
 
     #[test]
     fn text_format_clean_when_no_violations() {
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(4).build();
 
         let text = format_text(&result);
         assert!(text.contains("Health Score: 100.0/100"));
@@ -1771,36 +1668,15 @@ mod tests {
     fn json_report_includes_stability_violations() {
         use crate::analyzer::StabilityViolation;
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: vec![StabilityViolation {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(4)
+            .with_stability_violations(vec![StabilityViolation {
                 from_dir: "src/stable".into(),
                 to_dir: "src/unstable".into(),
                 from_instability: 0.17,
                 to_instability: 0.83,
-            }],
-        };
+            }])
+            .build();
         let report = JsonReport::from_audit(&modules, &result, "snap-s");
         let json = report.to_json().unwrap();
         let parsed: serde_json::Value = serde_json::from_str(&json).unwrap();
@@ -1816,36 +1692,15 @@ mod tests {
     fn json_report_includes_instability() {
         use crate::analyzer::InstabilityMetric;
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: vec![InstabilityMetric {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(4)
+            .with_instability(vec![InstabilityMetric {
                 dir: "src/core".into(),
                 ca: 5,
                 ce: 1,
                 instability: 1.0 / 6.0,
-            }],
-            stability_violations: Vec::new(),
-        };
+            }])
+            .build();
 
         let report = JsonReport::from_audit(&modules, &result, "snap-z");
         let json = report.to_json().unwrap();
@@ -1863,36 +1718,15 @@ mod tests {
     fn json_report_includes_abstractness() {
         use crate::analyzer::AbstractnessMetric;
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: vec![AbstractnessMetric {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(4)
+            .with_abstractness(vec![AbstractnessMetric {
                 dir: "src/api".into(),
                 abstract_count: 1,
                 concrete_count: 4,
                 abstractness: 0.2,
-            }],
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+            }])
+            .build();
 
         let report = JsonReport::from_audit(&modules, &result, "snap-z");
         let json = report.to_json().unwrap();
@@ -1911,36 +1745,15 @@ mod tests {
     #[test]
     fn text_format_includes_stability_violations() {
         use crate::analyzer::StabilityViolation;
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: vec![StabilityViolation {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(4)
+            .with_stability_violations(vec![StabilityViolation {
                 from_dir: "src/stable".into(),
                 to_dir: "src/unstable".into(),
                 from_instability: 0.17,
                 to_instability: 0.83,
-            }],
-        };
+            }])
+            .build();
         let text = format_text(&result);
         assert!(
             text.contains("Stability Violations:"),
@@ -1956,29 +1769,9 @@ mod tests {
     #[test]
     fn text_format_includes_instability_section() {
         use crate::analyzer::InstabilityMetric;
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: vec![
+        let result = AuditResultBuilder::new()
+            .with_total_modules(4)
+            .with_instability(vec![
                 InstabilityMetric {
                     dir: "src/app".into(),
                     ca: 0,
@@ -1991,9 +1784,8 @@ mod tests {
                     ce: 0,
                     instability: 0.0,
                 },
-            ],
-            stability_violations: Vec::new(),
-        };
+            ])
+            .build();
 
         let text = format_text(&result);
         assert!(text.contains("Instability:"), "missing header: {}", text);
@@ -2007,36 +1799,15 @@ mod tests {
     #[test]
     fn text_format_includes_abstractness_section() {
         use crate::analyzer::AbstractnessMetric;
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 4,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: vec![AbstractnessMetric {
+        let result = AuditResultBuilder::new()
+            .with_total_modules(4)
+            .with_abstractness(vec![AbstractnessMetric {
                 dir: "src/api".into(),
                 abstract_count: 2,
                 concrete_count: 3,
                 abstractness: 0.4,
-            }],
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+            }])
+            .build();
 
         let text = format_text(&result);
         assert!(
@@ -2065,31 +1836,7 @@ mod tests {
     #[test]
     fn markdown_has_heading_and_summary_table() {
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 5,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(5).build();
 
         let md = _format_markdown_single(&modules, &result, "snap-1");
         assert!(md.contains("# noupling Audit Report"));
@@ -2107,31 +1854,11 @@ mod tests {
             "dir_b".to_string(),
             "dir_a".to_string(),
         ];
-        let result = AuditResult {
-            violations: vec![v],
-            score: 50.0,
-            tri: 0.0,
-            total_modules: 2,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new()
+            .with_violations(vec![v])
+            .with_score(50.0)
+            .with_total_modules(2)
+            .build();
 
         let md = _format_markdown_single(&modules, &result, "snap-3");
         assert!(md.contains("## Circular Dependencies"));
@@ -2141,31 +1868,7 @@ mod tests {
     #[test]
     fn markdown_has_directory_tree() {
         let modules = vec![];
-        let result = AuditResult {
-            violations: vec![],
-            score: 100.0,
-            tri: 0.0,
-            total_modules: 3,
-            hotspots: Vec::new(),
-            rule_violations: Vec::new(),
-            layer_violations: Vec::new(),
-            cohesion: Vec::new(),
-            total_xs: 0,
-            independence: Vec::new(),
-            max_depth: 0,
-            critical_path: Vec::new(),
-            violation_age: ViolationAgeSummary::default(),
-            coupling_metrics_count: 0,
-            coupling_metrics: Vec::new(),
-            suppressed_count: 0,
-            gravity_wells: Vec::new(),
-            red_flags: Vec::new(),
-            external_deps: Vec::new(),
-            total_external_imports: 0,
-            abstractness: Vec::new(),
-            instability: Vec::new(),
-            stability_violations: Vec::new(),
-        };
+        let result = AuditResultBuilder::new().with_total_modules(3).build();
 
         let md = _format_markdown_single(&modules, &result, "snap-4");
         assert!(md.contains("## Directory Tree"));

--- a/src/scanner/mod.rs
+++ b/src/scanner/mod.rs
@@ -34,14 +34,7 @@ pub struct ExternalImportCount {
     pub count: usize,
 }
 
-/// Per-module count of abstract vs concrete type declarations.
-///
-/// Emitted by the scanner alongside dependencies; consumed by
-/// `analyzer::compute_abstractness` to derive per-directory abstractness.
-pub struct ModuleTypeCounts {
-    pub module_path: String,
-    pub counts: parsers::TypeCounts,
-}
+pub use crate::core::ModuleTypeCounts;
 
 /// Check if an import line is suppressed by a `noupling:ignore` comment.
 /// Checks the import line itself for an inline comment, and the line above

--- a/src/scanner/parsers/mod.rs
+++ b/src/scanner/parsers/mod.rs
@@ -30,16 +30,7 @@ pub struct ImportEntry {
     pub line_number: i32,
 }
 
-/// Per-file count of abstract vs concrete type declarations.
-///
-/// Abstract = trait / interface / abstract class. Concrete = everything else
-/// that declares a named type (struct, enum, class, etc.). Used to compute the
-/// Martin abstractness metric `A = abstract / (abstract + concrete)` per directory.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct TypeCounts {
-    pub abstract_count: usize,
-    pub concrete_count: usize,
-}
+pub use crate::core::TypeCounts;
 
 /// True when `path` ends with `candidate` on a `/`-separated segment boundary.
 ///


### PR DESCRIPTION
## Summary

Brings noupling's own health score back to 100/100 (was 97.9 after #215) and removes the three highest-leverage friction points the codebase audit surfaced this session.

### Stats: 12 files, +351 / -858 — a 507-line net reduction.

## Changes

### 1. Layer fix (the regression)

PR #215 introduced 4 layer violations by importing `scanner::ModuleTypeCounts` and `scanner::parsers::TypeCounts` into the `analyzer` layer (per the layer config, analyzer cannot depend on scanner). Moved both types to `core::{TypeCounts, ModuleTypeCounts}` — they're shared shapes consumed by both producers (scanner) and consumers (analyzer), so `core` is their natural home. Old paths preserved as re-exports so nothing externally breaks.

### 2. `AuditResultBuilder` for tests

`AuditResult` has 25 fields. ~37 test sites across `baseline.rs`, `reporter/{mod,html,graph}.rs` previously spelled out every field by hand. Adding a metric in #215 / #217 cost ~20 mechanical `field: Vec::new()` edits per PR.

The builder lives in `analyzer/mod.rs` behind `#[cfg(test)]` with sensible defaults (`score: 100.0`, empty vecs everywhere) and `with_*` setters. Tests now read like:

```rust
let result = AuditResultBuilder::new()
    .with_violations(vec![…])
    .with_score(75.0)
    .with_total_modules(4)
    .build();
```

Two effects: tests show their intent instead of their noise, and the next-metric-PR tax drops from ~20 sites to 1 default.

### 3. `LayerIndex` consolidates layer matching

`check_layer_rules`, `AuditResult::filter_by_layers`, and `AuditResult::apply_layer_weights` previously each compiled their own glob matchers and walked them independently. A bug in layer matching, or a change to the resolution rule, had to be fixed in three places.

New `LayerIndex` in `analyzer/layers.rs` compiles globs once and answers `layer_of(path) -> Option<(usize, &str)>`. All three call sites collapse to a one-liner.

**Behaviour change to flag**: `apply_layer_weights` previously had a `pattern.contains(extract_dir(path))` substring fallback after the glob check. No test exercised it and no use case was documented; removed. Surfaced in CHANGELOG.

## Verification

- [x] 241 unit + 5 integration tests pass with `RUSTFLAGS=-Dwarnings`
- [x] `cargo fmt --check` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `noupling audit .` on this branch: **Health Score 100.0/100, Violations: 0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)