### PR TITLE
feat(explorer): #274 new Levels tab — Finder-style one-level drill-down

### DIFF
--- a/crates/noupling-explorer/template/tests/e2e/smoke.spec.ts
+++ b/crates/noupling-explorer/template/tests/e2e/smoke.spec.ts
@@ -184,19 +184,11 @@ test.describe("Explorer — acme-payments sample", () => {
   }) => {
     await page.locator("button:has-text('Issues')").click();
     const firstCard = page.locator("#side-panel ul li button").first();
-    // Click activates focus mode.
     await firstCard.click();
-    // aria-pressed = "true" on the selected card (sticky).
     await expect(firstCard).toHaveAttribute("aria-pressed", "true");
-    // Focus banner is on the canvas.
-    await expect(
-      page.locator("text=Issue focused").first(),
-    ).toBeVisible();
-    // Esc clears the focus mode + sticky selected state.
+    await expect(page.locator("text=Issue focused").first()).toBeVisible();
     await page.keyboard.press("Escape");
-    await expect(
-      page.locator("text=Issue focused").first(),
-    ).not.toBeVisible();
+    await expect(page.locator("text=Issue focused").first()).not.toBeVisible();
   });
 
   test("Levels tab: containers only, double-click drills shared scope (#274)", async ({


### PR DESCRIPTION
Closes #274

## Summary
- Fifth tab **Levels** between Files and Issues
- Containers-only, one level at a time at the current shared scope
- Single-click selects; double-click drills shared scope
- Reuses `DrillBreadcrumb` from #273; per-row badges (file count + violation count)

## Test plan
- [x] 20/20 Playwright pass; new test covers tab presence, drill behaviour, breadcrumb back
- [x] cargo test --workspace clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)