### PR TITLE
refactor: deepen the audit pipeline into one module (#304)

### DIFF
--- a/crates/noupling-cli/src/audit_pipeline.rs
+++ b/crates/noupling-cli/src/audit_pipeline.rs
@@ -1,0 +1,364 @@
+//! Deep module pulling the load → filter → audit → enrich ladder out
+//! of the three callers (`audit`, `report`, `trend`) that previously
+//! inlined it. Issue #304.
+//!
+//! The interface is one method (`run`) plus an options struct. Behind
+//! it sit five stages — snapshot resolution, monorepo filtering, audit
+//! invocation, scan-meta enrichment, diff-filter application — each
+//! of which used to live as ~30 lines of copy-pasted boilerplate in
+//! every caller. Locality: when an invariant changes (e.g. how the
+//! diff filter interacts with external deps), it changes once.
+
+use anyhow::{Context, Result};
+use noupling_core::analyzer::{
+    self, check_dependency_rules, check_layer_rules, AuditResult, ExternalDepMetric,
+};
+use noupling_core::core::{Dependency, Module, Snapshot};
+use noupling_core::scanner;
+use noupling_core::settings::Settings;
+use noupling_core::storage::repository::{
+    DependencyRepository, ModuleRepository, SnapshotRepository,
+};
+use noupling_core::storage::Database;
+use std::collections::HashSet;
+use std::path::Path;
+
+/// Knobs that vary per call site. Defaults run against the latest
+/// snapshot with no monorepo split — what `report` does. `audit`
+/// supplies a specific snapshot id; both can supply a module filter.
+#[derive(Debug, Default)]
+pub struct PipelineOptions<'a> {
+    /// Snapshot to audit. `None` picks the most recent one (the
+    /// "latest" semantics that `report` and the no-arg form of
+    /// `audit` rely on).
+    pub snapshot_id: Option<&'a str>,
+    /// Monorepo split — restrict the audit to one configured module
+    /// from `settings.modules`. None = audit the whole codebase.
+    pub module_filter: Option<&'a str>,
+}
+
+/// Everything a caller needs after the pipeline runs. The fields
+/// audit/report previously assembled by hand are now returned in one
+/// shape, so post-pipeline steps (violation-age, baseline compare,
+/// format dispatch) stay clearly distinct from the shared ladder.
+#[derive(Debug)]
+pub struct PipelineOutcome {
+    pub snapshot: Snapshot,
+    pub modules: Vec<Module>,
+    pub dependencies: Vec<Dependency>,
+    pub result: AuditResult,
+}
+
+/// The seam. Owns the project path + db + settings for the duration
+/// of one or more `run()` calls.
+pub struct AuditPipeline<'a> {
+    project_path: &'a Path,
+    db: &'a Database,
+    settings: &'a Settings,
+}
+
+impl<'a> AuditPipeline<'a> {
+    pub fn new(project_path: &'a Path, db: &'a Database, settings: &'a Settings) -> Self {
+        Self {
+            project_path,
+            db,
+            settings,
+        }
+    }
+
+    pub fn run(&self, options: PipelineOptions<'_>) -> Result<PipelineOutcome> {
+        let snap_repo = SnapshotRepository::new(&self.db.conn);
+        let module_repo = ModuleRepository::new(&self.db.conn);
+        let dep_repo = DependencyRepository::new(&self.db.conn);
+
+        // (1) Load — resolve snapshot, then its modules + dependencies.
+        let snapshot = match options.snapshot_id {
+            Some(id) => snap_repo
+                .get_by_id(id)?
+                .with_context(|| format!("Snapshot not found: {}", id))?,
+            None => snap_repo
+                .get_latest()?
+                .context("No snapshots found. Run `noupling scan` first.")?,
+        };
+        let modules = module_repo.get_by_snapshot(&snapshot.id)?;
+        let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
+
+        // (2) Filter — apply the monorepo module split if requested.
+        let (filtered_modules, filtered_deps) = apply_module_filter(
+            &modules,
+            &dependencies,
+            self.settings,
+            options.module_filter,
+        )?;
+
+        // (3) Audit — single-project pipeline through the analyzer.
+        let type_counts = scanner::recompute_type_counts(self.project_path, &filtered_modules);
+        let mut result = analyzer::audit_with_settings(
+            &filtered_modules,
+            &filtered_deps,
+            &type_counts,
+            self.settings,
+        );
+        result.rule_violations = check_dependency_rules(
+            &filtered_modules,
+            &filtered_deps,
+            &self.settings.dependency_rules,
+        );
+        result.layer_violations =
+            check_layer_rules(&filtered_modules, &filtered_deps, &self.settings.layers);
+
+        // (4) Enrich with scan-time metadata (suppressed count + external
+        // deps) recorded at scan time.
+        let scan_meta = snap_repo.get_meta(&snapshot.id)?;
+        result.suppressed_count = scan_meta.suppressed_count;
+        result.external_deps = scan_meta
+            .external_deps
+            .iter()
+            .map(|e| ExternalDepMetric {
+                module_path: e.module_path.clone(),
+                count: e.count,
+            })
+            .collect();
+        result.total_external_imports = result.external_deps.iter().map(|e| e.count).sum();
+
+        // (5) Diff filter — if the scan ran against a diff base, narrow
+        // the result to the files that changed.
+        if let Some(ref changed_files) = scan_meta.diff_changed_files {
+            result.filter_by_changed_files(changed_files);
+        }
+
+        Ok(PipelineOutcome {
+            snapshot,
+            modules: filtered_modules,
+            dependencies: filtered_deps,
+            result,
+        })
+    }
+}
+
+fn apply_module_filter(
+    modules: &[Module],
+    dependencies: &[Dependency],
+    settings: &Settings,
+    module_filter: Option<&str>,
+) -> Result<(Vec<Module>, Vec<Dependency>)> {
+    let Some(name) = module_filter else {
+        return Ok((modules.to_vec(), dependencies.to_vec()));
+    };
+    let cfg = settings
+        .modules
+        .iter()
+        .find(|m| m.name == name)
+        .with_context(|| format!("Module '{}' not found in settings", name))?;
+    let prefix = format!("{}/", cfg.path);
+    let filtered_modules: Vec<_> = modules
+        .iter()
+        .filter(|m| m.path.starts_with(&prefix) || m.path == cfg.path)
+        .cloned()
+        .collect();
+    let ids: HashSet<&str> = filtered_modules.iter().map(|m| m.id.as_str()).collect();
+    let filtered_deps: Vec<_> = dependencies
+        .iter()
+        .filter(|d| {
+            ids.contains(d.from_module_id.as_str()) && ids.contains(d.to_module_id.as_str())
+        })
+        .cloned()
+        .collect();
+    Ok((filtered_modules, filtered_deps))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noupling_core::core::ModuleType;
+    use noupling_core::storage::{ExternalDepRow, SnapshotMeta};
+    use tempfile::TempDir;
+
+    /// Spin up a real on-disk SQLite (in a tempdir) — Database's
+    /// `open_in_memory` is `#[cfg(test)]` inside its own crate, so
+    /// downstream crates have to use the on-disk path. Snapshot, two
+    /// modules, one dependency.
+    struct Fixture {
+        _tmp: TempDir,
+        db: Database,
+        snapshot: Snapshot,
+    }
+
+    fn small_project() -> Fixture {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".noupling")).unwrap();
+        let db_path = tmp.path().join(".noupling").join("history.db");
+        let db = Database::open(&db_path).expect("open db");
+        let snap_repo = SnapshotRepository::new(&db.conn);
+        let snapshot = snap_repo
+            .create(tmp.path().to_str().unwrap())
+            .expect("snap");
+        let modules = vec![
+            Module {
+                id: "m-main".into(),
+                snapshot_id: snapshot.id.clone(),
+                parent_id: None,
+                name: "main.rs".into(),
+                path: "src/main.rs".into(),
+                module_type: ModuleType::File,
+                depth: 1,
+            },
+            Module {
+                id: "m-helper".into(),
+                snapshot_id: snapshot.id.clone(),
+                parent_id: None,
+                name: "helper.rs".into(),
+                path: "src/helper.rs".into(),
+                module_type: ModuleType::File,
+                depth: 1,
+            },
+        ];
+        ModuleRepository::new(&db.conn)
+            .bulk_insert(&modules)
+            .unwrap();
+        DependencyRepository::new(&db.conn)
+            .bulk_insert(&[Dependency {
+                from_module_id: "m-main".into(),
+                to_module_id: "m-helper".into(),
+                line_number: 1,
+            }])
+            .unwrap();
+        Fixture {
+            _tmp: tmp,
+            db,
+            snapshot,
+        }
+    }
+
+    fn empty_settings() -> Settings {
+        serde_json::from_str("{}").expect("default settings")
+    }
+
+    #[test]
+    fn pipeline_resolves_latest_snapshot_and_loads_its_modules_and_deps() {
+        let f = small_project();
+        let settings = empty_settings();
+        let pipeline = AuditPipeline::new(Path::new("/tmp"), &f.db, &settings);
+
+        let outcome = pipeline.run(PipelineOptions::default()).expect("run");
+
+        assert_eq!(outcome.snapshot.id, f.snapshot.id);
+        assert_eq!(outcome.modules.len(), 2);
+        assert_eq!(outcome.dependencies.len(), 1);
+        assert!(outcome.result.score > 0.0);
+    }
+
+    #[test]
+    fn pipeline_enriches_result_with_scan_meta() {
+        let f = small_project();
+        SnapshotRepository::new(&f.db.conn)
+            .save_meta(
+                &f.snapshot.id,
+                &SnapshotMeta {
+                    suppressed_count: 7,
+                    diff_base: None,
+                    diff_changed_files: None,
+                    external_deps: vec![ExternalDepRow {
+                        module_path: "src/main.rs".into(),
+                        count: 3,
+                    }],
+                },
+            )
+            .expect("save meta");
+        let settings = empty_settings();
+        let pipeline = AuditPipeline::new(Path::new("/tmp"), &f.db, &settings);
+
+        let outcome = pipeline.run(PipelineOptions::default()).expect("run");
+
+        assert_eq!(outcome.result.suppressed_count, 7);
+        assert_eq!(outcome.result.external_deps.len(), 1);
+        assert_eq!(outcome.result.total_external_imports, 3);
+    }
+
+    #[test]
+    fn pipeline_applies_diff_filter_when_scan_meta_records_changed_files() {
+        let f = small_project();
+        SnapshotRepository::new(&f.db.conn)
+            .save_meta(
+                &f.snapshot.id,
+                &SnapshotMeta {
+                    suppressed_count: 0,
+                    diff_base: Some("HEAD~1".into()),
+                    diff_changed_files: Some(vec!["src/main.rs".into()]),
+                    external_deps: vec![],
+                },
+            )
+            .expect("save meta");
+        let settings = empty_settings();
+        let pipeline = AuditPipeline::new(Path::new("/tmp"), &f.db, &settings);
+
+        let outcome = pipeline.run(PipelineOptions::default()).expect("run");
+
+        // Clean fixture has no violations either way — the assertion is
+        // that the call succeeded with the diff filter applied without
+        // panicking. Behaviour of filter_by_changed_files itself is
+        // covered by noupling-core's own tests.
+        assert!(outcome.result.violations.is_empty());
+    }
+
+    #[test]
+    fn pipeline_splits_monorepo_modules_when_filter_supplied() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        std::fs::create_dir_all(tmp.path().join(".noupling")).unwrap();
+        let db = Database::open(&tmp.path().join(".noupling").join("history.db")).unwrap();
+        let snap = SnapshotRepository::new(&db.conn)
+            .create(tmp.path().to_str().unwrap())
+            .unwrap();
+        ModuleRepository::new(&db.conn)
+            .bulk_insert(&[
+                Module {
+                    id: "m-orders".into(),
+                    snapshot_id: snap.id.clone(),
+                    parent_id: None,
+                    name: "a.rs".into(),
+                    path: "services/orders/a.rs".into(),
+                    module_type: ModuleType::File,
+                    depth: 2,
+                },
+                Module {
+                    id: "m-billing".into(),
+                    snapshot_id: snap.id.clone(),
+                    parent_id: None,
+                    name: "b.rs".into(),
+                    path: "services/billing/b.rs".into(),
+                    module_type: ModuleType::File,
+                    depth: 2,
+                },
+            ])
+            .unwrap();
+        let settings: Settings =
+            serde_json::from_str(r#"{"modules":[{"name":"orders","path":"services/orders"}]}"#)
+                .unwrap();
+
+        let pipeline = AuditPipeline::new(Path::new("/tmp"), &db, &settings);
+        let outcome = pipeline
+            .run(PipelineOptions {
+                snapshot_id: None,
+                module_filter: Some("orders"),
+            })
+            .expect("run");
+
+        assert_eq!(outcome.modules.len(), 1);
+        assert_eq!(outcome.modules[0].path, "services/orders/a.rs");
+    }
+
+    #[test]
+    fn pipeline_errors_when_unknown_module_filter_supplied() {
+        let f = small_project();
+        let settings = empty_settings();
+        let pipeline = AuditPipeline::new(Path::new("/tmp"), &f.db, &settings);
+
+        let err = pipeline
+            .run(PipelineOptions {
+                snapshot_id: None,
+                module_filter: Some("ghost"),
+            })
+            .unwrap_err();
+        assert!(err.to_string().contains("ghost"));
+    }
+}

--- a/crates/noupling-cli/src/commands/audit.rs
+++ b/crates/noupling-cli/src/commands/audit.rs
@@ -80,40 +80,32 @@ pub fn run(
         return Ok(());
     }
 
-    // Single-project mode (existing behavior)
-    let type_counts =
-        noupling_core::scanner::recompute_type_counts(std::path::Path::new(path), &modules);
-    let mut result = noupling_core::analyzer::audit_with_settings(
-        &modules,
-        &dependencies,
-        &type_counts,
-        &project_settings,
-    );
-    result.rule_violations = noupling_core::analyzer::check_dependency_rules(
-        &modules,
-        &dependencies,
-        &project_settings.dependency_rules,
-    );
-    result.layer_violations = noupling_core::analyzer::check_layer_rules(
-        &modules,
-        &dependencies,
-        &project_settings.layers,
-    );
+    // Single-project mode — the load → filter → audit → enrich → diff
+    // ladder lives in AuditPipeline (#304). This caller owns only the
+    // audit-specific extras (diff-mode print, violation age, baseline
+    // compare, fail-below).
 
-    // Load scan-time metadata from SQLite
-    let scan_meta = snap_repo.get_meta(&snapshot.id)?;
-    result.suppressed_count = scan_meta.suppressed_count;
-    result.external_deps = scan_meta
-        .external_deps
-        .iter()
-        .map(|e| noupling_core::analyzer::ExternalDepMetric {
-            module_path: e.module_path.clone(),
-            count: e.count,
-        })
-        .collect();
-    result.total_external_imports = result.external_deps.iter().map(|e| e.count).sum();
+    // Pre-pipeline: surface the diff-mode banner. The pipeline applies
+    // the filter; we just want the user-facing print.
+    let pre_meta = snap_repo.get_meta(&snapshot.id)?;
+    if pre_meta.diff_changed_files.is_some() {
+        if let Some(ref base) = pre_meta.diff_base {
+            if !base.is_empty() {
+                println!("Diff mode: filtered to changes against {}", base);
+            }
+        }
+    }
 
-    // Compute violation age from snapshot history
+    let pipeline =
+        crate::audit_pipeline::AuditPipeline::new(Path::new(path), &db, &project_settings);
+    let crate::audit_pipeline::PipelineOutcome { mut result, .. } =
+        pipeline.run(crate::audit_pipeline::PipelineOptions {
+            snapshot_id: Some(&snapshot.id),
+            module_filter,
+        })?;
+
+    // Compute violation age from snapshot history. Specific to audit;
+    // not part of the shared pipeline.
     let all_snapshots = snap_repo.get_all()?;
     let mut historical: Vec<Vec<(String, String)>> = Vec::new();
     for s in &all_snapshots {
@@ -132,16 +124,6 @@ pub fn run(
     }
     result.violation_age =
         noupling_core::analyzer::compute_violation_age(&result.violations, &historical);
-
-    // Apply diff filter if a diff scan was performed
-    if let Some(ref changed_files) = scan_meta.diff_changed_files {
-        if let Some(ref base) = scan_meta.diff_base {
-            if !base.is_empty() {
-                println!("Diff mode: filtered to changes against {}", base);
-            }
-        }
-        result.filter_by_changed_files(changed_files);
-    }
 
     // Apply baseline filter
     let baseline_info = if use_baseline {

--- a/crates/noupling-cli/src/commands/report.rs
+++ b/crates/noupling-cli/src/commands/report.rs
@@ -12,84 +12,25 @@ pub fn run(
     explorer_no_history: bool,
 ) -> anyhow::Result<()> {
     let db = super::find_db(path)?;
-    let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
-
-    let snapshot = snap_repo
-        .get_latest()?
-        .ok_or_else(|| anyhow::anyhow!("No snapshots found. Run `noupling scan` first."))?;
-
-    let module_repo = noupling_core::storage::repository::ModuleRepository::new(&db.conn);
-    let dep_repo = noupling_core::storage::repository::DependencyRepository::new(&db.conn);
-
-    let modules = module_repo.get_by_snapshot(&snapshot.id)?;
-    let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
-
     let project_settings = noupling_core::settings::Settings::load(Path::new(path))?;
 
-    // If --module specified with monorepo config, filter to that module's files
-    let (report_modules, report_deps) = if let Some(name) = module_filter {
-        let cfg = project_settings
-            .modules
-            .iter()
-            .find(|m| m.name == name)
-            .ok_or_else(|| anyhow::anyhow!("Module '{}' not found in settings", name))?;
-        let prefix = format!("{}/", cfg.path);
-        let filtered_modules: Vec<_> = modules
-            .iter()
-            .filter(|m| m.path.starts_with(&prefix) || m.path == cfg.path)
-            .cloned()
-            .collect();
-        let module_ids: std::collections::HashSet<&str> =
-            filtered_modules.iter().map(|m| m.id.as_str()).collect();
-        let filtered_deps: Vec<_> = dependencies
-            .iter()
-            .filter(|d| {
-                module_ids.contains(d.from_module_id.as_str())
-                    && module_ids.contains(d.to_module_id.as_str())
-            })
-            .cloned()
-            .collect();
-        (filtered_modules, filtered_deps)
-    } else {
-        (modules, dependencies)
-    };
-
-    let type_counts =
-        noupling_core::scanner::recompute_type_counts(Path::new(path), &report_modules);
-    let mut result = noupling_core::analyzer::audit_with_settings(
-        &report_modules,
-        &report_deps,
-        &type_counts,
-        &project_settings,
-    );
-    result.rule_violations = noupling_core::analyzer::check_dependency_rules(
-        &report_modules,
-        &report_deps,
-        &project_settings.dependency_rules,
-    );
-    result.layer_violations = noupling_core::analyzer::check_layer_rules(
-        &report_modules,
-        &report_deps,
-        &project_settings.layers,
-    );
-
-    // Load scan-time metadata from SQLite
-    let scan_meta = snap_repo.get_meta(&snapshot.id)?;
-    result.suppressed_count = scan_meta.suppressed_count;
-    result.external_deps = scan_meta
-        .external_deps
-        .iter()
-        .map(|e| noupling_core::analyzer::ExternalDepMetric {
-            module_path: e.module_path.clone(),
-            count: e.count,
-        })
-        .collect();
-    result.total_external_imports = result.external_deps.iter().map(|e| e.count).sum();
-
-    // Apply diff filter if a diff scan was performed
-    if let Some(ref changed_files) = scan_meta.diff_changed_files {
-        result.filter_by_changed_files(changed_files);
-    }
+    // The shared load → filter → audit → enrich → diff-filter ladder
+    // is now in the AuditPipeline (#304). This caller owns only the
+    // bits specific to `report` (save_health_score + format dispatch).
+    let pipeline =
+        crate::audit_pipeline::AuditPipeline::new(Path::new(path), &db, &project_settings);
+    let crate::audit_pipeline::PipelineOutcome {
+        snapshot,
+        modules: report_modules,
+        dependencies: report_deps,
+        result,
+    } = pipeline.run(crate::audit_pipeline::PipelineOptions {
+        snapshot_id: None,
+        module_filter,
+    })?;
+    let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
+    let module_repo = noupling_core::storage::repository::ModuleRepository::new(&db.conn);
+    let dep_repo = noupling_core::storage::repository::DependencyRepository::new(&db.conn);
 
     // Persist the score on the snapshot row so the Explorer's history
     // scrubber (PRD §10.5) can render a trend over time, even when the

--- a/crates/noupling-cli/src/main.rs
+++ b/crates/noupling-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod audit_pipeline;
 mod cli;
 mod commands;
 mod hook;


### PR DESCRIPTION
Closes #304 (top recommendation from the architecture review).

## What changed

Pulled the shared `load → filter → audit → enrich → diff` ladder out of `audit.rs` and `report.rs` into a new `audit_pipeline` module with one `run()` method and a `PipelineOutcome` struct.

- New module: `crates/noupling-cli/src/audit_pipeline.rs` (one method behind the seam, ~140 LOC implementation, 5 focused inline tests).
- `commands/report.rs` and `commands/audit.rs` migrated; each now opens with one `pipeline.run(opts)?` call and focuses on what's specific to it (save_health_score + format dispatch / violation-age + baseline compare + fail-below threshold).
- `commands/trend.rs` is intentionally **not** migrated: it passes empty `type_counts` deliberately ("can't be recomputed reliably from current source") and skips scan-meta enrichment — different shape, not a fit for this seam. One adapter today; the hypothetical seam stays hypothetical.

## Wins (per the deepening rationale)

- **locality** — pipeline invariants (scan-meta enrichment order, diff filter application, monorepo split semantics) live in one place.
- **deletion test passes** — two callers re-stitched ~60 lines of boilerplate; deleting the seam would put the drift back.
- **interface shrinks** — `audit.run` for report.rs is now one call + 6 lines of post-processing instead of ~88 lines.
- **leverage** — adding a future command that needs the same ladder reuses the seam.

## TDD discipline

- 5 new pipeline tests written tracer-bullet style (one test, one extraction step, run-and-green).
- 8 existing CLI e2e tests (`tests/cli.rs`) act as the regression check — all green after migration.
- Full workspace: **297 tests, 0 failures**.
- cargo clippy --workspace -- -D warnings: clean.
- cargo fmt: clean.

## Out of scope

- trend.rs migration (deliberate — different shape, see above).
- The 12-arm format-dispatch (#301) — also part of report.rs but a separate refactor with its own seam.
- DatabaseSession (#308) — would simplify pipeline construction; out of scope here, blocked by no second caller yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)