### PR TITLE
refactor: deepen DatabaseSession seam, drop find_db (#308)

### DIFF
--- a/crates/noupling-cli/src/commands/audit.rs
+++ b/crates/noupling-cli/src/commands/audit.rs
@@ -7,8 +7,10 @@ pub fn run(
     use_baseline: bool,
     module_filter: Option<&str>,
 ) -> anyhow::Result<()> {
-    let db = super::find_db(path)?;
-    let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
+    let session = crate::db_session::DatabaseSession::open(path)?;
+    let snap_repo = session.snapshots();
+    let module_repo = session.modules();
+    let dep_repo = session.dependencies();
 
     let snapshot = match snapshot_id {
         Some(id) => snap_repo
@@ -18,9 +20,6 @@ pub fn run(
             .get_latest()?
             .ok_or_else(|| anyhow::anyhow!("No snapshots found. Run `noupling scan` first."))?,
     };
-
-    let module_repo = noupling_core::storage::repository::ModuleRepository::new(&db.conn);
-    let dep_repo = noupling_core::storage::repository::DependencyRepository::new(&db.conn);
 
     let modules = module_repo.get_by_snapshot(&snapshot.id)?;
     let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
@@ -97,7 +96,7 @@ pub fn run(
     }
 
     let pipeline =
-        crate::audit_pipeline::AuditPipeline::new(Path::new(path), &db, &project_settings);
+        crate::audit_pipeline::AuditPipeline::new(Path::new(path), session.db(), &project_settings);
     let crate::audit_pipeline::PipelineOutcome { mut result, .. } =
         pipeline.run(crate::audit_pipeline::PipelineOptions {
             snapshot_id: Some(&snapshot.id),

--- a/crates/noupling-cli/src/commands/baseline.rs
+++ b/crates/noupling-cli/src/commands/baseline.rs
@@ -3,16 +3,13 @@ use std::path::Path;
 pub fn run(action: &str, path: &str) -> anyhow::Result<()> {
     match action {
         "save" => {
-            let db = super::find_db(path)?;
-            let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
-            let snapshot = snap_repo
+            let session = crate::db_session::DatabaseSession::open(path)?;
+            let snapshot = session
+                .snapshots()
                 .get_latest()?
                 .ok_or_else(|| anyhow::anyhow!("No snapshots found. Run `noupling scan` first."))?;
-
-            let module_repo = noupling_core::storage::repository::ModuleRepository::new(&db.conn);
-            let dep_repo = noupling_core::storage::repository::DependencyRepository::new(&db.conn);
-            let modules = module_repo.get_by_snapshot(&snapshot.id)?;
-            let dependencies = dep_repo.get_by_snapshot(&snapshot.id)?;
+            let modules = session.modules().get_by_snapshot(&snapshot.id)?;
+            let dependencies = session.dependencies().get_by_snapshot(&snapshot.id)?;
 
             let project_settings = noupling_core::settings::Settings::load(Path::new(path))?;
             let type_counts =

--- a/crates/noupling-cli/src/commands/mod.rs
+++ b/crates/noupling-cli/src/commands/mod.rs
@@ -5,16 +5,3 @@ pub mod init;
 pub mod report;
 pub mod scan;
 pub mod trend;
-
-use std::path::Path;
-
-pub(crate) fn find_db(project_path: &str) -> anyhow::Result<noupling_core::storage::Database> {
-    let db_path = Path::new(project_path).join(".noupling").join("history.db");
-    if !db_path.exists() {
-        anyhow::bail!(
-            "No database found at {}. Run `noupling scan <PATH>` first.",
-            db_path.display()
-        );
-    }
-    noupling_core::storage::Database::open(&db_path)
-}

--- a/crates/noupling-cli/src/commands/report.rs
+++ b/crates/noupling-cli/src/commands/report.rs
@@ -11,14 +11,17 @@ pub fn run(
     explorer_title: Option<&str>,
     explorer_no_history: bool,
 ) -> anyhow::Result<()> {
-    let db = super::find_db(path)?;
+    let session = crate::db_session::DatabaseSession::open(path)?;
+    let snap_repo = session.snapshots();
+    let module_repo = session.modules();
+    let dep_repo = session.dependencies();
     let project_settings = noupling_core::settings::Settings::load(Path::new(path))?;
 
     // The shared load → filter → audit → enrich → diff-filter ladder
-    // is now in the AuditPipeline (#304). This caller owns only the
-    // bits specific to `report` (save_health_score + format dispatch).
+    // is in the AuditPipeline (#304). This caller owns only the bits
+    // specific to `report` (save_health_score + format dispatch).
     let pipeline =
-        crate::audit_pipeline::AuditPipeline::new(Path::new(path), &db, &project_settings);
+        crate::audit_pipeline::AuditPipeline::new(Path::new(path), session.db(), &project_settings);
     let crate::audit_pipeline::PipelineOutcome {
         snapshot,
         modules: report_modules,
@@ -28,9 +31,6 @@ pub fn run(
         snapshot_id: None,
         module_filter,
     })?;
-    let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
-    let module_repo = noupling_core::storage::repository::ModuleRepository::new(&db.conn);
-    let dep_repo = noupling_core::storage::repository::DependencyRepository::new(&db.conn);
 
     // Persist the score on the snapshot row so the Explorer's history
     // scrubber (PRD §10.5) can render a trend over time, even when the
@@ -123,8 +123,7 @@ pub fn run(
             println!("Report saved to {}", file_path.display());
         }
         "pr" => {
-            // Compute deltas from previous snapshot if available
-            let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
+            // Compute deltas from previous snapshot if available.
             let all = snap_repo.get_all()?;
             let prev = all.iter().rfind(|s| s.id != snapshot.id).cloned();
             let (prev_score, prev_count) = if let Some(prev_snap) = prev {
@@ -276,7 +275,6 @@ pub fn run(
             println!("Report saved to {}", file_path.display());
         }
         "strategy" => {
-            let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
             let file_path = report_dir.join("strategy.html");
             crate::reporter::generate_strategy_report(
                 &snap_repo,
@@ -322,8 +320,7 @@ pub fn run(
                     }
                 }
             }
-            // Strategy needs snapshot history — handle separately
-            let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
+            // Strategy needs snapshot history — handle separately.
             let strategy_path = report_dir.join("strategy.html");
             match crate::reporter::generate_strategy_report(
                 &snap_repo,

--- a/crates/noupling-cli/src/commands/scan.rs
+++ b/crates/noupling-cli/src/commands/scan.rs
@@ -23,7 +23,9 @@ pub fn run(path: &str, diff_base: Option<&str>) -> anyhow::Result<()> {
 
     let db_path = project_path.join(".noupling").join("history.db");
     let db = noupling_core::storage::Database::open(&db_path)?;
-
+    // scan owns its own Database for the initial create-or-open path
+    // (DatabaseSession::open expects an existing db). All subsequent
+    // commands flow through DatabaseSession.
     let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
     let snapshot = snap_repo.create(path)?;
     println!("Created snapshot: {}", snapshot.id);

--- a/crates/noupling-cli/src/commands/trend.rs
+++ b/crates/noupling-cli/src/commands/trend.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
 pub fn run(path: &str, last: usize, by_module: bool) -> anyhow::Result<()> {
-    let db = super::find_db(path)?;
-    let snap_repo = noupling_core::storage::repository::SnapshotRepository::new(&db.conn);
-    let module_repo = noupling_core::storage::repository::ModuleRepository::new(&db.conn);
-    let dep_repo = noupling_core::storage::repository::DependencyRepository::new(&db.conn);
+    let session = crate::db_session::DatabaseSession::open(path)?;
+    let snap_repo = session.snapshots();
+    let module_repo = session.modules();
+    let dep_repo = session.dependencies();
 
     let project_settings = noupling_core::settings::Settings::load(Path::new(path))?;
     let snapshots = snap_repo.get_all()?;

--- a/crates/noupling-cli/src/db_session.rs
+++ b/crates/noupling-cli/src/db_session.rs
@@ -1,0 +1,134 @@
+//! Deep module that owns the SQLite database and lends repositories
+//! to command handlers (#308). Eighteen callsites used to open a
+//! database and construct three `Repository::new(&db.conn)` lines by
+//! hand; with the session, each callsite is one `open()` plus typed
+//! accessors that lend the repo with the right lifetime.
+//!
+//! The session also owns the "find or fail" semantics of `find_db` —
+//! a missing `.noupling/history.db` is the same error everywhere
+//! ("Run `noupling scan` first"), so locality stays in one place.
+
+use anyhow::Result;
+use noupling_core::storage::repository::{
+    DependencyRepository, ModuleRepository, SnapshotRepository,
+};
+use noupling_core::storage::Database;
+use std::path::Path;
+
+/// A connected SQLite session against a project's `.noupling/history.db`.
+/// Construct with `open(path)`; access the typed repos via the
+/// accessors. Each accessor returns a repo borrowing the session for
+/// its lifetime — cheap to construct, never owns state of its own.
+pub struct DatabaseSession {
+    db: Database,
+}
+
+impl DatabaseSession {
+    /// Open the project's history database. Bails with the standard
+    /// "run `noupling scan` first" guidance when the file is absent.
+    pub fn open(project_path: &str) -> Result<Self> {
+        let db_path = Path::new(project_path).join(".noupling").join("history.db");
+        if !db_path.exists() {
+            anyhow::bail!(
+                "No database found at {}. Run `noupling scan <PATH>` first.",
+                db_path.display()
+            );
+        }
+        let db = Database::open(&db_path)?;
+        Ok(Self { db })
+    }
+
+    /// Direct access to the underlying `Database` — only the few
+    /// callers that still take `&Database` (notably AuditPipeline)
+    /// need this. Everyone else should use the typed accessors.
+    pub fn db(&self) -> &Database {
+        &self.db
+    }
+
+    pub fn snapshots(&self) -> SnapshotRepository<'_> {
+        SnapshotRepository::new(&self.db.conn)
+    }
+
+    pub fn modules(&self) -> ModuleRepository<'_> {
+        ModuleRepository::new(&self.db.conn)
+    }
+
+    pub fn dependencies(&self) -> DependencyRepository<'_> {
+        DependencyRepository::new(&self.db.conn)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noupling_core::core::{Module, ModuleType};
+    use tempfile::TempDir;
+
+    /// Build a project tree with an initialised history.db so the
+    /// session can open it. Returns the tempdir + the project path
+    /// string so test bodies can call open(path) directly.
+    fn project_with_db() -> (TempDir, String) {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().to_str().unwrap().to_string();
+        std::fs::create_dir_all(tmp.path().join(".noupling")).unwrap();
+        // Force schema initialisation by opening once. The session will
+        // open again — repeated initialisation is idempotent per the
+        // CREATE TABLE IF NOT EXISTS pattern in storage::db.
+        let db_path = tmp.path().join(".noupling").join("history.db");
+        let _ = Database::open(&db_path).expect("init schema");
+        (tmp, project)
+    }
+
+    #[test]
+    fn open_returns_session_for_existing_database() {
+        let (_tmp, project) = project_with_db();
+        let session = DatabaseSession::open(&project).expect("open session");
+        // Smoke: a fresh db has no snapshots.
+        let snaps = session.snapshots().get_all().expect("list snaps");
+        assert!(snaps.is_empty());
+    }
+
+    #[test]
+    fn open_bails_when_history_db_missing() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let project = tmp.path().to_str().unwrap().to_string();
+        let result = DatabaseSession::open(&project);
+        match result {
+            Ok(_) => panic!("expected error when history.db is missing"),
+            Err(err) => assert!(
+                err.to_string().contains("Run `noupling scan <PATH>` first"),
+                "got: {}",
+                err
+            ),
+        }
+    }
+
+    #[test]
+    fn accessors_return_independent_repo_views_borrowing_the_session() {
+        // Two repos from one session must both work without conflict —
+        // the session is the seam, not the individual repos.
+        let (_tmp, project) = project_with_db();
+        let session = DatabaseSession::open(&project).expect("open session");
+
+        let snap = session.snapshots().create("/tmp/example").expect("snap");
+        session
+            .modules()
+            .bulk_insert(&[Module {
+                id: "m-1".into(),
+                snapshot_id: snap.id.clone(),
+                parent_id: None,
+                name: "main.rs".into(),
+                path: "src/main.rs".into(),
+                module_type: ModuleType::File,
+                depth: 1,
+            }])
+            .expect("insert");
+
+        let loaded = session
+            .modules()
+            .get_by_snapshot(&snap.id)
+            .expect("load modules");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].path, "src/main.rs");
+    }
+}

--- a/crates/noupling-cli/src/main.rs
+++ b/crates/noupling-cli/src/main.rs
@@ -1,6 +1,7 @@
 mod audit_pipeline;
 mod cli;
 mod commands;
+mod db_session;
 mod hook;
 mod reporter;
 


### PR DESCRIPTION
Closes #308.

## What changed

A new `DatabaseSession` deep module owns the project's history.db and lends typed repos to callers. Eighteen callsites that previously hand-rolled `find_db` + three `Repository::new` lines now open one session and call `session.snapshots()` / `.modules()` / `.dependencies()`.

- New: `crates/noupling-cli/src/db_session.rs` (~60 LOC implementation + 3 inline tests).
- Migrated: `audit`, `report`, `trend`, `baseline`.
- `scan` keeps its own Database for the initial create-or-open path (session expects an existing db); documented inline.
- `find_db` and its bespoke error message are deleted — the session owns the same semantics in one place.

## Wins

- **locality** — "missing db → run `noupling scan` first" lives in one place.
- **leverage** — new commands reuse the session by construction.
- **deletion test** — without the session, callers re-grow ~4 lines of bookkeeping each.

## TDD discipline

- 3 inline tests: opens existing db; bails when db missing; accessors share the session.
- Existing 8 CLI e2e tests in `tests/cli.rs` are the regression check — all green after migration.
- Full workspace: **300 tests, 0 failures** (up from 297; the new module's 3 tests).
- cargo clippy --workspace -- -D warnings: clean.

## Out of scope

- Updating `AuditPipeline` to take `&DatabaseSession` directly. It still takes `&Database` and callers pass `session.db()`. Worth a follow-up; left out to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)