### PR TITLE
refactor: ReportFormatter trait + registry for the simple formats (#301)

### DIFF
--- a/crates/noupling-cli/src/commands/report.rs
+++ b/crates/noupling-cli/src/commands/report.rs
@@ -40,15 +40,28 @@ pub fn run(
     let report_dir = Path::new(path).join(".noupling");
     std::fs::create_dir_all(&report_dir)?;
 
-    match format {
-        "json" => {
-            let report =
-                crate::reporter::JsonReport::from_audit(&report_modules, &result, &snapshot.id);
-            let content = report.to_json()?;
-            let file_path = report_dir.join("report.json");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
+    // The six simple formats (string + file + print) are now adapters
+    // behind a single registry (#301). Anything that matches an
+    // adapter returns here; complex formats — markdown, html, bundle,
+    // dashboard, pr, explorer, strategy, all — keep their bespoke
+    // arms below because their input shapes differ.
+    let registry = crate::report_formatter::builtin_formatters();
+    let ctx = crate::report_formatter::FormatterContext {
+        modules: &report_modules,
+        result: &result,
+        snapshot: &snapshot,
+        report_dir: &report_dir,
+    };
+    if let Some(out) = crate::report_formatter::dispatch(format, &ctx, &registry)? {
+        std::fs::write(&out.file_path, &out.content)?;
+        println!("Report saved to {}", out.file_path.display());
+        if let Some(tail) = out.success_tail {
+            println!("{}", tail);
         }
+        return Ok(());
+    }
+
+    match format {
         "md" => {
             let md_dir = report_dir.join("report-md");
             crate::reporter::generate_markdown_report(
@@ -58,22 +71,6 @@ pub fn run(
                 &md_dir,
             )?;
             println!("Report saved to {}/README.md", md_dir.display());
-        }
-        "xml" => {
-            let content = crate::reporter::format_xml(&report_modules, &result, &snapshot.id);
-            let file_path = report_dir.join("report.xml");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
-        "sonar" => {
-            let content = crate::reporter::format_sonar(&result);
-            let file_path = report_dir.join("noupling-sonar.json");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-            println!(
-                "Add to sonar-project.properties: sonar.externalIssuesReportPaths={}",
-                file_path.display()
-            );
         }
         "html" => {
             let html_dir = report_dir.join("report");
@@ -85,22 +82,6 @@ pub fn run(
                 &project_settings,
             )?;
             println!("Report saved to {}/index.html", html_dir.display());
-        }
-        "mermaid" => {
-            let content = crate::reporter::format_mermaid(&report_modules, &result);
-            let file_path = report_dir.join("report.mermaid");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
-        "dot" => {
-            let content = crate::reporter::format_dot(&report_modules, &result);
-            let file_path = report_dir.join("report.dot");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-            println!(
-                "Render with: dot -Tpng {} -o graph.png",
-                file_path.display()
-            );
         }
         "bundle" => {
             let file_path = report_dir.join("bundle.html");
@@ -142,12 +123,6 @@ pub fn run(
 
             let content = crate::reporter::format_pr(&result, prev_score, prev_count, None, None);
             let file_path = report_dir.join("pr.md");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
-        "briefing" => {
-            let content = crate::reporter::format_briefing(&result);
-            let file_path = report_dir.join("briefing.md");
             std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());
         }
@@ -309,7 +284,7 @@ pub fn run(
                     &report_modules,
                     &report_deps,
                     &result,
-                    &snapshot.id,
+                    &snapshot,
                     &project_settings,
                 );
                 match r {
@@ -367,56 +342,43 @@ fn generate_single_format(
     modules: &[noupling_core::core::Module],
     deps: &[noupling_core::core::Dependency],
     result: &noupling_core::analyzer::AuditResult,
-    snapshot_id: &str,
+    snapshot: &noupling_core::core::Snapshot,
     settings: &noupling_core::settings::Settings,
 ) -> anyhow::Result<()> {
+    // Try the simple-format registry first — six of the eleven `all`
+    // arms (json, xml, sonar, mermaid, dot, briefing) go through it.
+    let registry = crate::report_formatter::builtin_formatters();
+    let ctx = crate::report_formatter::FormatterContext {
+        modules,
+        result,
+        snapshot,
+        report_dir,
+    };
+    if let Some(out) = crate::report_formatter::dispatch(format, &ctx, &registry)? {
+        std::fs::write(&out.file_path, &out.content)?;
+        println!("Report saved to {}", out.file_path.display());
+        // The success-tail messages are noisy in `all`-mode; suppress
+        // them and only print on the focused arms.
+        return Ok(());
+    }
+
+    // Complex formats that don't fit the simple seam yet.
     match format {
-        "json" => {
-            let report = crate::reporter::JsonReport::from_audit(modules, result, snapshot_id);
-            let content = report.to_json()?;
-            let file_path = report_dir.join("report.json");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
         "md" => {
             let md_dir = report_dir.join("report-md");
-            crate::reporter::generate_markdown_report(modules, result, snapshot_id, &md_dir)?;
+            crate::reporter::generate_markdown_report(modules, result, &snapshot.id, &md_dir)?;
             println!("Report saved to {}/README.md", md_dir.display());
-        }
-        "xml" => {
-            let content = crate::reporter::format_xml(modules, result, snapshot_id);
-            let file_path = report_dir.join("report.xml");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
-        "sonar" => {
-            let content = crate::reporter::format_sonar(result);
-            let file_path = report_dir.join("noupling-sonar.json");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
         }
         "html" => {
             let html_dir = report_dir.join("report");
             crate::reporter::generate_html_report(
                 modules,
                 result,
-                snapshot_id,
+                &snapshot.id,
                 &html_dir,
                 settings,
             )?;
             println!("Report saved to {}/index.html", html_dir.display());
-        }
-        "mermaid" => {
-            let content = crate::reporter::format_mermaid(modules, result);
-            let file_path = report_dir.join("report.mermaid");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
-        "dot" => {
-            let content = crate::reporter::format_dot(modules, result);
-            let file_path = report_dir.join("report.dot");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
         }
         "bundle" => {
             let file_path = report_dir.join("bundle.html");
@@ -432,12 +394,6 @@ fn generate_single_format(
             // Without snapshot history context, generate a simple current-state PR report.
             let content = crate::reporter::format_pr(result, None, None, None, None);
             let file_path = report_dir.join("pr.md");
-            std::fs::write(&file_path, &content)?;
-            println!("Report saved to {}", file_path.display());
-        }
-        "briefing" => {
-            let content = crate::reporter::format_briefing(result);
-            let file_path = report_dir.join("briefing.md");
             std::fs::write(&file_path, &content)?;
             println!("Report saved to {}", file_path.display());
         }

--- a/crates/noupling-cli/src/main.rs
+++ b/crates/noupling-cli/src/main.rs
@@ -3,6 +3,7 @@ mod cli;
 mod commands;
 mod db_session;
 mod hook;
+mod report_formatter;
 mod reporter;
 
 use clap::Parser;

--- a/crates/noupling-cli/src/report_formatter.rs
+++ b/crates/noupling-cli/src/report_formatter.rs
@@ -1,0 +1,294 @@
+//! ReportFormatter trait + registry (#301). Eight of the report-format
+//! arms used to repeat the same three-line pattern in `report.rs`:
+//! compute string, write to `report_dir/file.ext`, print
+//! `"Report saved to …"`. This pulls that into one seam — each adapter
+//! is a tiny module owning *which file name and what bytes*, and the
+//! dispatch is one registry lookup.
+//!
+//! The format families that don't fit this shape (Explorer, PR, HTML,
+//! Markdown, Bundle, Dashboard, Strategy, the composite "all") stay
+//! as bespoke match arms in `report.rs`. They have different inputs —
+//! a second adapter would justify expanding the seam to cover them.
+//! One adapter today = hypothetical seam.
+
+use anyhow::Result;
+use noupling_core::analyzer::AuditResult;
+use noupling_core::core::{Module, Snapshot};
+use std::path::{Path, PathBuf};
+
+/// Inputs an adapter needs to render. Kept narrow — anything an
+/// adapter doesn't use lives outside this struct so the seam stays
+/// honest.
+pub struct FormatterContext<'a> {
+    pub modules: &'a [Module],
+    pub result: &'a AuditResult,
+    pub snapshot: &'a Snapshot,
+    pub report_dir: &'a Path,
+}
+
+/// What an adapter returns. The caller writes the file and prints the
+/// (optional) success-tail message uniformly — the format-specific
+/// "Render with: dot …" / "Add to sonar-project.properties…" lines
+/// belong to the format, not the dispatcher.
+pub struct FormattedReport {
+    pub file_path: PathBuf,
+    pub content: String,
+    pub success_tail: Option<String>,
+}
+
+/// The seam. One method, one outcome.
+pub trait ReportFormatter {
+    fn name(&self) -> &'static str;
+    fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport>;
+}
+
+/// Built-in adapters — the eight string-and-file simple formats.
+pub fn builtin_formatters() -> Vec<Box<dyn ReportFormatter>> {
+    vec![
+        Box::new(adapters::Json),
+        Box::new(adapters::Xml),
+        Box::new(adapters::Sonar),
+        Box::new(adapters::Mermaid),
+        Box::new(adapters::Dot),
+        Box::new(adapters::Briefing),
+    ]
+}
+
+/// Dispatch a format string against the registry. Returns the rendered
+/// report when one of the adapters matches; `None` lets the caller
+/// fall through to its bespoke match arms.
+pub fn dispatch<'a>(
+    format: &str,
+    ctx: &FormatterContext<'a>,
+    registry: &[Box<dyn ReportFormatter>],
+) -> Result<Option<FormattedReport>> {
+    for adapter in registry {
+        if adapter.name() == format {
+            return adapter.render(ctx).map(Some);
+        }
+    }
+    Ok(None)
+}
+
+mod adapters {
+    use super::*;
+    use crate::reporter;
+
+    pub struct Json;
+    impl ReportFormatter for Json {
+        fn name(&self) -> &'static str {
+            "json"
+        }
+        fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport> {
+            let report =
+                reporter::JsonReport::from_audit(ctx.modules, ctx.result, &ctx.snapshot.id);
+            Ok(FormattedReport {
+                file_path: ctx.report_dir.join("report.json"),
+                content: report.to_json()?,
+                success_tail: None,
+            })
+        }
+    }
+
+    pub struct Xml;
+    impl ReportFormatter for Xml {
+        fn name(&self) -> &'static str {
+            "xml"
+        }
+        fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport> {
+            Ok(FormattedReport {
+                file_path: ctx.report_dir.join("report.xml"),
+                content: reporter::format_xml(ctx.modules, ctx.result, &ctx.snapshot.id),
+                success_tail: None,
+            })
+        }
+    }
+
+    pub struct Sonar;
+    impl ReportFormatter for Sonar {
+        fn name(&self) -> &'static str {
+            "sonar"
+        }
+        fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport> {
+            let file_path = ctx.report_dir.join("noupling-sonar.json");
+            let tail = format!(
+                "Add to sonar-project.properties: sonar.externalIssuesReportPaths={}",
+                file_path.display()
+            );
+            Ok(FormattedReport {
+                file_path,
+                content: reporter::format_sonar(ctx.result),
+                success_tail: Some(tail),
+            })
+        }
+    }
+
+    pub struct Mermaid;
+    impl ReportFormatter for Mermaid {
+        fn name(&self) -> &'static str {
+            "mermaid"
+        }
+        fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport> {
+            Ok(FormattedReport {
+                file_path: ctx.report_dir.join("report.mermaid"),
+                content: reporter::format_mermaid(ctx.modules, ctx.result),
+                success_tail: None,
+            })
+        }
+    }
+
+    pub struct Dot;
+    impl ReportFormatter for Dot {
+        fn name(&self) -> &'static str {
+            "dot"
+        }
+        fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport> {
+            let file_path = ctx.report_dir.join("report.dot");
+            let tail = format!(
+                "Render with: dot -Tpng {} -o graph.png",
+                file_path.display()
+            );
+            Ok(FormattedReport {
+                file_path,
+                content: reporter::format_dot(ctx.modules, ctx.result),
+                success_tail: Some(tail),
+            })
+        }
+    }
+
+    pub struct Briefing;
+    impl ReportFormatter for Briefing {
+        fn name(&self) -> &'static str {
+            "briefing"
+        }
+        fn render(&self, ctx: &FormatterContext<'_>) -> Result<FormattedReport> {
+            Ok(FormattedReport {
+                file_path: ctx.report_dir.join("briefing.md"),
+                content: reporter::format_briefing(ctx.result),
+                success_tail: None,
+            })
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use noupling_core::analyzer::AuditResultBuilder;
+    use noupling_core::core::{Module, ModuleType, Snapshot};
+    use tempfile::TempDir;
+
+    /// Tiny scaffolding for each adapter test: one snapshot, one
+    /// module, a default audit result. Returned by-value so the test
+    /// can take references off them with normal borrow rules.
+    struct Scaffold {
+        _tmp: TempDir,
+        report_dir: PathBuf,
+        modules: Vec<Module>,
+        result: AuditResult,
+        snapshot: Snapshot,
+    }
+
+    fn scaffold() -> Scaffold {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let report_dir = tmp.path().to_path_buf();
+        let modules = vec![Module {
+            id: "m-1".into(),
+            snapshot_id: "snap-1".into(),
+            parent_id: None,
+            name: "main.rs".into(),
+            path: "src/main.rs".into(),
+            module_type: ModuleType::File,
+            depth: 1,
+        }];
+        let result = AuditResultBuilder::new().build();
+        let snapshot = Snapshot {
+            id: "snap-1".into(),
+            timestamp: "2026-06-05T00:00:00".into(),
+            root_path: tmp.path().to_string_lossy().to_string(),
+        };
+        Scaffold {
+            _tmp: tmp,
+            report_dir,
+            modules,
+            result,
+            snapshot,
+        }
+    }
+
+    #[test]
+    fn registry_includes_all_six_simple_formats() {
+        let names: Vec<&'static str> = builtin_formatters().iter().map(|f| f.name()).collect();
+        assert!(names.contains(&"json"));
+        assert!(names.contains(&"xml"));
+        assert!(names.contains(&"sonar"));
+        assert!(names.contains(&"mermaid"));
+        assert!(names.contains(&"dot"));
+        assert!(names.contains(&"briefing"));
+    }
+
+    #[test]
+    fn dispatch_returns_none_when_format_is_unknown() {
+        let s = scaffold();
+        let ctx = FormatterContext {
+            modules: &s.modules,
+            result: &s.result,
+            snapshot: &s.snapshot,
+            report_dir: &s.report_dir,
+        };
+        let out = dispatch("explorer", &ctx, &builtin_formatters()).expect("ok");
+        assert!(
+            out.is_none(),
+            "explorer doesn't live in the simple registry"
+        );
+    }
+
+    #[test]
+    fn dispatch_renders_json_with_default_file_name() {
+        let s = scaffold();
+        let ctx = FormatterContext {
+            modules: &s.modules,
+            result: &s.result,
+            snapshot: &s.snapshot,
+            report_dir: &s.report_dir,
+        };
+        let out = dispatch("json", &ctx, &builtin_formatters())
+            .expect("ok")
+            .expect("json adapter matched");
+        assert!(out.file_path.ends_with("report.json"));
+        assert!(out.content.starts_with("{"), "got: {}", out.content);
+        assert!(out.success_tail.is_none());
+    }
+
+    #[test]
+    fn sonar_carries_the_sonar_project_properties_hint_as_a_tail() {
+        let s = scaffold();
+        let ctx = FormatterContext {
+            modules: &s.modules,
+            result: &s.result,
+            snapshot: &s.snapshot,
+            report_dir: &s.report_dir,
+        };
+        let out = dispatch("sonar", &ctx, &builtin_formatters())
+            .expect("ok")
+            .expect("sonar matched");
+        let tail = out.success_tail.expect("sonar tail set");
+        assert!(tail.contains("sonar.externalIssuesReportPaths"));
+    }
+
+    #[test]
+    fn dot_carries_the_render_hint_as_a_tail() {
+        let s = scaffold();
+        let ctx = FormatterContext {
+            modules: &s.modules,
+            result: &s.result,
+            snapshot: &s.snapshot,
+            report_dir: &s.report_dir,
+        };
+        let out = dispatch("dot", &ctx, &builtin_formatters())
+            .expect("ok")
+            .expect("dot matched");
+        let tail = out.success_tail.expect("dot tail set");
+        assert!(tail.contains("dot -Tpng"));
+    }
+}


### PR DESCRIPTION
Closes #301.

## What changed

A `ReportFormatter` trait + `FormatterContext` + `FormattedReport` shape now sit behind a single seam in `report_formatter.rs`. The dispatcher tries the registry first; an `Option<FormattedReport>` of `Some` short-circuits the bespoke match in `report.rs::run()` and in the `all`-mode helper.

- New module: `crates/noupling-cli/src/report_formatter.rs` — trait, context, six adapters (`Json`, `Xml`, `Sonar`, `Mermaid`, `Dot`, `Briefing`), 5 inline tests.
- `commands/report.rs::run()` simple arms collapsed: 6 arms × ~6 lines each → one dispatch + one write/print tail.
- `commands/report.rs::generate_single_format` (the `all`-mode helper) also uses the registry.

## Why not all 12 formats

The complex arms (md, html, bundle, dashboard, pr, explorer, strategy, all) have meaningfully different input shapes — strategy needs the three repos, explorer needs auto-detected layers + enrichment + resolved snapshot, pr needs prev-snapshot deltas. **One adapter today = hypothetical seam.** When a second adapter (a second strategy variant, a second explorer-like flow) lands, we extend `FormatterContext`. Adding them now would be over-engineering.

## Wins

- **locality** — file name + content + tail message live with the format.
- **leverage** — adding a simple format = one struct + one `Box::new(…)` in the registry.
- **interface shrinks** — `report.rs::run()` simple arms went from 6 × 6 lines = 36 lines to ~12 lines of dispatch + tail.
- **deletion test passes** — without the seam, six callers re-grow the same three-line tail.

## TDD discipline

- 5 inline tests written tracer-bullet style (registry shape, unknown-format passthrough, json path, sonar tail, dot tail).
- 8 existing CLI e2e tests (including `report_format_all_emits_files_for_each_format`) act as the regression check — all green.
- Full workspace: **305 tests, 0 failures**.
- cargo clippy --workspace -- -D warnings: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)